### PR TITLE
Append to series on action Scheduled to Published

### DIFF
--- a/orgSeries-taxonomy.php
+++ b/orgSeries-taxonomy.php
@@ -121,6 +121,7 @@ function set_series_order($postid = 0, $series_part = 0, $series_id, $is_publish
 
 	$total_posts = is_array($series_posts) ? count( $series_posts ) + 1 : 1;
 
+	// Find out how many posts in this series are unpublished
 	$unpub_count = 0;
 	foreach ( $series_posts as $sposts ) {
 		$spostid = $sposts['id'];
@@ -130,6 +131,8 @@ function set_series_order($postid = 0, $series_part = 0, $series_id, $is_publish
 		}
 	}
 
+	// If the given Series Part is either higher than the current # of published posts, <=0, or # of published posts is only one,
+	// then set variable $series_part to the maximum value
 	$published_posts = $total_posts - $unpub_count;
 	if ( (isset($total_posts)) && ( ($published_posts < $series_part ) || $series_part <=  0 || $published_posts == 1 ) ) {
 		if ( ($published_posts >= 1) && $is_published ) {
@@ -187,7 +190,7 @@ function set_series_order($postid = 0, $series_part = 0, $series_id, $is_publish
 					}
 				}
 
-				if ( !in_array($rise_part, $parts_array) && ($currentpart != $count) ) {
+				if ( !in_array($rise_part, $parts_array) && (($currentpart != $count ) && ($currentpart !== '')) ) {
 					if ( (($series_part == 1 ) && ($series_part >= $currentpart)) || (( $series_part == $currentpart ) && !$drop && ($currentpart - $oldpart) < 2) || (( $series_part < $currentpart ) && ( $currentpart == $oldpart ) && !$drop && ($currentpart != $count)) ) {
 						$newpart = $rise_part;
 						$rise = TRUE;
@@ -453,6 +456,9 @@ function wp_set_post_series_transition( $post ) {
 	$post_ID = $post->ID;
 	$ser_id = wp_get_post_series($post_ID);
 	wp_set_post_series( $post_ID, $post, true, $ser_id, true );
+	// ensure the post is added as the last part in the series
+	$current_part = wp_series_part( $post_ID, $ser_id );
+	if( empty($current_part) ) set_series_order( $post_ID, 0, $ser_id, true );
 }
 
 function wp_set_post_series_draft_transition( $post ) {

--- a/orgSeries-taxonomy.php
+++ b/orgSeries-taxonomy.php
@@ -158,7 +158,7 @@ function set_series_order($postid = 0, $series_part = 0, $series_id, $is_publish
 			$is_was_rise = FALSE;
 
 			$spost_pchange=TRUE;
-			$current_published = TRUE;
+			$current_published = $spost_status == "publish";
 
 			$rise_part = $currentpart + 1;
 			$drop_part = $currentpart - 1;
@@ -221,7 +221,7 @@ function set_series_order($postid = 0, $series_part = 0, $series_id, $is_publish
 				}
 			}
 
-			if ( !isset($newpart) ) {
+			if ( !isset($newpart) ) { // we don't need to change this post's part
 				$newpart = $currentpart;
 			}
 


### PR DESCRIPTION
#70 
When a Scheduled Post with an unset Series Part goes from Scheduled to Published, it will be added as the last item in that Series. This means you don't need to remember which part number you are on as you schedule series post uploads.

Also fixed a perceived bug: Previously, when scheduling more that one post to be added to a Series without providing the Series Part to any of them, each subsequent scheduled post would take the "empty" Series part position, and increment all other posts in the series. As a result, if you scheduled n posts to a series, the first n-1 posts you scheduled would become the first n-1 posts in that series, incrementing all the others. With this, all scheduled posts for which a Series Part is not given by the user will remain as such until they are published.