### PR TITLE
feature/#362-HTML_tags_being_stripped_when_saving

### DIFF
--- a/orgSeries-options.php
+++ b/orgSeries-options.php
@@ -134,44 +134,44 @@ function orgseries_validate($input) {
 	}
 	//toggles and paging info
 	$newinput['auto_tag_toggle'] = isset($input['auto_tag_toggle']) && $input['auto_tag_toggle'] == 1 ? 1 : 0;
-	$newinput['series_post_list_limit'] = trim(stripslashes(sanitize_text_field($input['series_post_list_limit'])));
+	$newinput['series_post_list_limit'] = trim(stripslashes(($input['series_post_list_limit'])));
 	$newinput['auto_tag_nav_toggle'] = ( isset($input['auto_tag_nav_toggle']) && $input['auto_tag_nav_toggle'] == 1 ? 1 : 0 );
 	$newinput['auto_tag_seriesmeta_toggle'] = ( isset($input['auto_tag_seriesmeta_toggle']) && $input['auto_tag_seriesmeta_toggle'] == 1 ? 1 : 0 );
 	$newinput['custom_css'] = ( isset($input['custom_css']) && $input['custom_css'] == 1 ? 1 : 0 );
-	$newinput['series_css_tougle'] = ( isset($input['series_css_tougle']) ? trim(stripslashes(sanitize_text_field($input['series_css_tougle'])), 1) : 'default' );
+	$newinput['series_css_tougle'] = ( isset($input['series_css_tougle']) ? trim(stripslashes(($input['series_css_tougle'])), 1) : 'default' );
 	$newinput['kill_on_delete'] = ( isset($input['kill_on_delete']) && $input['kill_on_delete'] == 1 ? 1 : 0 );
-	$newinput['series_toc_url'] = preg_replace('/(^\/)|(\/$)/', '', sanitize_text_field($input['series_toc_url']));
-	$newinput['series_custom_base'] = preg_replace('/(^\/)|(\/$)/', '', sanitize_text_field($input['series_custom_base']));
+	$newinput['series_toc_url'] = preg_replace('/(^\/)|(\/$)/', '', ($input['series_toc_url']));
+	$newinput['series_custom_base'] = preg_replace('/(^\/)|(\/$)/', '', ($input['series_custom_base']));
 
-	$newinput['series_perp_toc'] = trim(preg_replace('/[^0-9]/', '', sanitize_text_field($input['series_perp_toc'])));
+	$newinput['series_perp_toc'] = trim(preg_replace('/[^0-9]/', '', ($input['series_perp_toc'])));
 
 	if ( strlen($input['series_toc_url']) <= 0 ) $newinput['series_toc_url'] = false;
-	$newinput['series_toc_title'] = isset($input['series_toc_title']) ? trim(stripslashes(sanitize_text_field($input['series_toc_title']))) : '';
-	$newinput['orgseries_api'] = isset($input['orgseries_api']) ? trim(sanitize_text_field($input['orgseries_api'])) : '';
+	$newinput['series_toc_title'] = isset($input['series_toc_title']) ? trim(stripslashes(($input['series_toc_title']))) : '';
+	$newinput['orgseries_api'] = isset($input['orgseries_api']) ? trim(($input['orgseries_api'])) : '';
 
 	//template options
-	$newinput['series_post_list_template'] = trim(stripslashes(sanitize_text_field($input['series_post_list_template'])));
-	$newinput['series_post_list_post_template'] = trim(stripslashes(sanitize_text_field($input['series_post_list_post_template'])));
-	$newinput['series_post_list_currentpost_template'] = trim(stripslashes(sanitize_text_field($input['series_post_list_currentpost_template'])));
-	$newinput['series_meta_template'] = trim(stripslashes(sanitize_text_field($input['series_meta_template'])));
-	$newinput['series_meta_excerpt_template'] = trim(stripslashes(sanitize_text_field($input['series_meta_excerpt_template'])));
-    $newinput['series_table_of_contents_box_template'] = trim(stripslashes(sanitize_text_field($input['series_table_of_contents_box_template'])));
-	$newinput['series_post_nav_template'] = trim(stripslashes(sanitize_text_field($input['series_post_nav_template'])));
-	$newinput['series_nextpost_nav_custom_text'] = trim(stripslashes(sanitize_text_field($input['series_nextpost_nav_custom_text'])));
-	$newinput['series_prevpost_nav_custom_text'] = trim(stripslashes(sanitize_text_field($input['series_prevpost_nav_custom_text'])));
-	$newinput['series_firstpost_nav_custom_text'] = trim(stripslashes(sanitize_text_field($input['series_firstpost_nav_custom_text'])));
-	$newinput['series_posts_orderby'] = trim(stripslashes(sanitize_text_field($input['series_posts_orderby'])));
-	$newinput['series_posts_order'] = trim(stripslashes(sanitize_text_field($input['series_posts_order'])));
-	$newinput['latest_series_before_template'] = trim(stripslashes(sanitize_text_field($input['latest_series_before_template'])));
-	$newinput['latest_series_inner_template'] = trim(stripslashes(sanitize_text_field($input['latest_series_inner_template'])));
-	$newinput['latest_series_after_template'] = trim(stripslashes(sanitize_text_field($input['latest_series_after_template'])));
-	$newinput['series_post_list_position'] = trim(stripslashes(sanitize_text_field($input['series_post_list_position'])));
-	$newinput['series_metabox_position'] = trim(stripslashes(sanitize_text_field($input['series_metabox_position'])));
-	$newinput['series_navigation_box_position'] = trim(stripslashes(sanitize_text_field($input['series_navigation_box_position'])));
-	$newinput['series_taxonomy_slug'] = ( isset($input['series_taxonomy_slug']) && !empty(trim($input['series_taxonomy_slug'])) ? sanitize_text_field($input['series_taxonomy_slug']) : 'series' );
+	$newinput['series_post_list_template'] = trim(stripslashes(($input['series_post_list_template'])));
+	$newinput['series_post_list_post_template'] = trim(stripslashes(($input['series_post_list_post_template'])));
+	$newinput['series_post_list_currentpost_template'] = trim(stripslashes(($input['series_post_list_currentpost_template'])));
+	$newinput['series_meta_template'] = trim(stripslashes(($input['series_meta_template'])));
+	$newinput['series_meta_excerpt_template'] = trim(stripslashes(($input['series_meta_excerpt_template'])));
+    $newinput['series_table_of_contents_box_template'] = trim(stripslashes(($input['series_table_of_contents_box_template'])));
+	$newinput['series_post_nav_template'] = trim(stripslashes(($input['series_post_nav_template'])));
+	$newinput['series_nextpost_nav_custom_text'] = trim(stripslashes(($input['series_nextpost_nav_custom_text'])));
+	$newinput['series_prevpost_nav_custom_text'] = trim(stripslashes(($input['series_prevpost_nav_custom_text'])));
+	$newinput['series_firstpost_nav_custom_text'] = trim(stripslashes(($input['series_firstpost_nav_custom_text'])));
+	$newinput['series_posts_orderby'] = trim(stripslashes(($input['series_posts_orderby'])));
+	$newinput['series_posts_order'] = trim(stripslashes(($input['series_posts_order'])));
+	$newinput['latest_series_before_template'] = trim(stripslashes(($input['latest_series_before_template'])));
+	$newinput['latest_series_inner_template'] = trim(stripslashes(($input['latest_series_inner_template'])));
+	$newinput['latest_series_after_template'] = trim(stripslashes(($input['latest_series_after_template'])));
+	$newinput['series_post_list_position'] = trim(stripslashes(($input['series_post_list_position'])));
+	$newinput['series_metabox_position'] = trim(stripslashes(($input['series_metabox_position'])));
+	$newinput['series_navigation_box_position'] = trim(stripslashes(($input['series_navigation_box_position'])));
+	$newinput['series_taxonomy_slug'] = ( isset($input['series_taxonomy_slug']) && !empty(trim($input['series_taxonomy_slug'])) ? ($input['series_taxonomy_slug']) : 'series' );
 
     // overview page options
-    $newinput['series_overview_page_layout'] = trim(stripslashes(sanitize_text_field($input['series_overview_page_layout'])));
+    $newinput['series_overview_page_layout'] = trim(stripslashes(($input['series_overview_page_layout'])));
     $newinput['series_overview_page_columns'] = (int) $input['series_overview_page_columns'];
 
 	//series-icon related settings
@@ -180,7 +180,7 @@ function orgseries_validate($input) {
 	$newinput['series_icon_width_latest_series'] = (int) $input['series_icon_width_latest_series'];
 
     //we need to maintain series slug settings separately
-    update_option('pp_series_taxonomy_slug', sanitize_text_field($newinput['series_taxonomy_slug']));
+    update_option('pp_series_taxonomy_slug', ($newinput['series_taxonomy_slug']));
 
 	$newinput['last_modified'] = gmdate("D, d M Y H:i:s", time());
 	$return_input = apply_filters('orgseries_options', $newinput, $input);


### PR DESCRIPTION
- HTML tags being stripped when saving close #362

This issue is fixed but to restore template, user will need to reset options in settings since the html part has already been stripped off.