### PR TITLE
Upgrade icon column type to TEXT in database

### DIFF
--- a/inc/utility-functions.php
+++ b/inc/utility-functions.php
@@ -106,7 +106,7 @@ if (!function_exists('pp_series_upgrade_function')) {
                 //create table for series icons
                 $sql = "CREATE TABLE $table_name (
                 term_id INT NOT NULL,
-                icon VARCHAR(100) NOT NULL,
+                icon ΤΕΧΤ NOT NULL,
                 PRIMARY KEY  (term_id)
             )";
                 require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
@@ -118,7 +118,34 @@ if (!function_exists('pp_series_upgrade_function')) {
             update_option('pp_series_2_11_1_upgraded', true);
         }
 
-
+        /**
+        * Upgrade icon column from VARCHAR(100) to TEXT
+        */
+        if (!get_option('pp_series_3_1_3_upgraded')) {
+                $table_name = $wpdb->prefix . "orgseriesicons";
+                 // Ensure table exists
+                 if ($wpdb->get_var("SHOW TABLES LIKE '$table_name'") == $table_name) {
+                     $column = $wpdb->get_row(
+                         $wpdb->prepare(
+                             "SHOW COLUMNS FROM `$table_name` LIKE %s",
+                             'icon' )
+                     );
+                     
+                     // Upgrade old installs
+                     if ($column && isset($column->Type)) {
+                         if (
+                             stripos($column->Type, 'varchar(100)') !== false ||
+                             stripos($column->Type, 'varchar(255)') !== false
+                         ) {
+                             $wpdb->query(
+                                 "ALTER TABLE `$table_name`
+                                 MODIFY `icon` TEXT NOT NULL"
+                             );
+                         }
+                     }
+                 }
+            update_option('pp_series_3_1_3_upgraded', true);
+        }
     }
 }
 

--- a/inc/utility-functions.php
+++ b/inc/utility-functions.php
@@ -102,11 +102,12 @@ if (!function_exists('pp_series_upgrade_function')) {
 
         if (!get_option('pp_series_2_11_1_upgraded')) {
             $table_name = $wpdb->prefix . "orgseriesicons";
-            if ($wpdb->get_var("SHOW TABLES LIKE '$table_name'") != $table_name) {
+            $table_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_name'") === $table_name;
+            if (!$table_exists) {
                 //create table for series icons
                 $sql = "CREATE TABLE $table_name (
                 term_id INT NOT NULL,
-                icon ΤΕΧΤ NOT NULL,
+                icon TEXT NOT NULL,
                 PRIMARY KEY  (term_id)
             )";
                 require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
@@ -114,37 +115,49 @@ if (!function_exists('pp_series_upgrade_function')) {
                 add_option('series_icon_path', '');
                 add_option('series_icon_url', '');
                 add_option('series_icon_filetypes', 'jpg gif jpeg png');
+
+                $table_exists = $wpdb->get_var("SHOW TABLES LIKE '$table_name'") === $table_name;
             }
-            update_option('pp_series_2_11_1_upgraded', true);
+
+            if ($table_exists) {
+                update_option('pp_series_2_11_1_upgraded', true);
+            }
         }
 
         /**
-        * Upgrade icon column from VARCHAR(100) to TEXT
-        */
+         * Upgrade icon column from VARCHAR(100) to TEXT.
+         *
+         * dbDelta() handles both new tables and existing tables. The option is
+         * only set after verifying that the column has the new type, so a
+         * failed database operation can be retried on the next admin request.
+         */
         if (!get_option('pp_series_3_1_3_upgraded')) {
-                $table_name = $wpdb->prefix . "orgseriesicons";
-                 // Ensure table exists
-                 if ($wpdb->get_var("SHOW TABLES LIKE '$table_name'") == $table_name) {
-                     $column = $wpdb->get_row(
-                         $wpdb->prepare(
-                             "SHOW COLUMNS FROM `$table_name` LIKE %s",
-                             'icon' )
-                     );
-                     
-                     // Upgrade old installs
-                     if ($column && isset($column->Type)) {
-                         if (
-                             stripos($column->Type, 'varchar(100)') !== false ||
-                             stripos($column->Type, 'varchar(255)') !== false
-                         ) {
-                             $wpdb->query(
-                                 "ALTER TABLE `$table_name`
-                                 MODIFY `icon` TEXT NOT NULL"
-                             );
-                         }
-                     }
-                 }
-            update_option('pp_series_3_1_3_upgraded', true);
+            $table_name = $wpdb->prefix . "orgseriesicons";
+
+            require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
+            $sql = "CREATE TABLE $table_name (
+                term_id INT NOT NULL,
+                icon TEXT NOT NULL,
+                PRIMARY KEY  (term_id)
+            )";
+            dbDelta($sql);
+
+            if ($wpdb->get_var("SHOW TABLES LIKE '$table_name'") === $table_name) {
+                $column = $wpdb->get_row(
+                    $wpdb->prepare(
+                        "SHOW COLUMNS FROM `$table_name` LIKE %s",
+                        'icon'
+                    )
+                );
+
+                if (
+                    $column
+                    && isset($column->Type)
+                    && in_array(strtolower($column->Type), array('text', 'mediumtext', 'longtext'), true)
+                ) {
+                    update_option('pp_series_3_1_3_upgraded', true);
+                }
+            }
         }
     }
 }

--- a/orgSeries-icon.php
+++ b/orgSeries-icon.php
@@ -87,12 +87,58 @@ function seriesicons_write($series, $icon) {
     }
 
 	if ($wpdb->get_var( $wpdb->prepare("SELECT term_id FROM `$tablename` WHERE term_id=%d", $series) ) ) {
-		$wpdb->query( $wpdb->prepare("UPDATE `$tablename` SET icon=%s WHERE term_id=%d", $icon, $series) );
+		$result = $wpdb->update( $tablename, array('icon' => $icon), array('term_id' => $series), array('%s'), array('%d') );
 	} else {
-        $wpdb->insert($tablename, array('icon' => $icon, 'term_id' => $series), array('%s','%d'));
+        $result = $wpdb->insert($tablename, array('icon' => $icon, 'term_id' => $series), array('%s','%d'));
 	}
+
+	/**
+	 * $wpdb::update() returns 0 when the stored value is already the same, which
+	 * is not a failure. Only false means the query itself did not run.
+	 */
+	if ( false === $result ) {
+		seriesicons_write_error( $wpdb->last_error );
+		return false;
+	}
+
 	return true;
 }
+
+/**
+* Record a failed series icon write so that seriesicons_write_error_notice() can report it.
+* @param string $db_error The error message reported by $wpdb.
+*/
+function seriesicons_write_error($db_error = '') {
+	if ( ! function_exists('set_transient') || ! is_admin() ) {
+		return;
+	}
+
+	set_transient( 'pp_series_icon_write_error_' . get_current_user_id(), (string) $db_error, 5 * MINUTE_IN_SECONDS );
+}
+
+/**
+* Tell the user that the series icon was not saved, instead of failing silently.
+*/
+function seriesicons_write_error_notice() {
+	$transient_key = 'pp_series_icon_write_error_' . get_current_user_id();
+	$db_error = get_transient( $transient_key );
+
+	if ( false === $db_error ) {
+		return;
+	}
+
+	delete_transient( $transient_key );
+
+	$message = __('PublishPress Series could not save the series icon. The icon was not changed.', 'organize-series');
+
+	if ( '' !== $db_error ) {
+		/* translators: %s: the error message reported by the database. */
+		$message .= ' ' . sprintf( __('Database error: %s', 'organize-series'), $db_error );
+	}
+
+	printf( '<div class="notice notice-error"><p>%s</p></div>', esc_html( $message ) );
+}
+add_action( 'admin_notices', 'seriesicons_write_error_notice' );
 
 /**
 * Database delete function to remove the series icon/series relationship from the database.
@@ -106,7 +152,8 @@ function seriesicons_delete($series) {
 
 	if ( empty($series)  || '' == $series  )	return false;
 
-	$wpdb->query( $wpdb->prepare("DELETE FROM $tablename WHERE term_id=%d", $series) );
-	return true;
+	$result = $wpdb->delete( $tablename, array('term_id' => $series), array('%d') );
+
+	return false !== $result;
 }
 ?>


### PR DESCRIPTION
Upgraded the 'icon' column in the 'orgseriesicons' table from VARCHAR(100) to TEXT to accommodate larger icon data.

Fix for the bug described in  https://wordpress.org/support/topic/series-icon-urls-are-silently-truncated-due-to-varchar100-column-limit/