### PR TITLE
Add Dependabot triage workflow (#1145)

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -1,0 +1,24 @@
+name: Dependabot Alert Triage
+
+on:
+  schedule:
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log matching alerts without dismissing them
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  dependabot_triage:
+    name: Auto-dismiss dev-only Dependabot alerts
+    uses: publishpress/github-workflows/.github/workflows/dependabot-triage.yml@v3
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit


### PR DESCRIPTION
## What

- Add the reusable Dependabot alert triage workflow.
- Run it weekly on Mondays and expose a manual dry-run input.
- Grant only the contents and security-events permissions required by the workflow.

## Why

Adds the workflow requested in #1145 using the shared PublishPress GitHub Workflows v3 implementation.

## Checks

- `git diff --cached --check`
- No test files added.