### PR TITLE
Link PRO badges to the Series banner (#1148)

### DIFF
--- a/addons/post-details/includes/class-admin-ui.php
+++ b/addons/post-details/includes/class-admin-ui.php
@@ -269,7 +269,7 @@ class PPS_Series_Post_Details_Admin_UI
                 <div class="pps-category-separator">
                     <h4 class="category-title"><?php echo esc_html($args['label']); ?></h4>
                     <?php if ($pro_locked): ?>
-                        <span class="ppseries-pro-badge" style="padding: 1px 10px;">PRO</span>
+                        <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer" style="padding: 1px 10px;">PRO</a>
                         <span class="tooltip-text">
                             <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
                             <i></i>
@@ -354,7 +354,7 @@ class PPS_Series_Post_Details_Admin_UI
 
                 // If PRO-locked, end wrapper
                 if ($pro_locked): ?>
-                    <span class="ppseries-pro-badge">PRO</span>
+                    <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a>
                     <span class="tooltip-text">
                         <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
                         <i></i>

--- a/addons/post-list-box/includes/class-admin-ui.php
+++ b/addons/post-list-box/includes/class-admin-ui.php
@@ -426,7 +426,7 @@ class PPS_Post_List_Box_Admin_UI {
                             <span class="item"><?php echo esc_html($args['label']); ?></span>
                             <?php if ($key === 'layout' && !pp_series_is_pro_active()) : ?>
                                 <span class="ppseries-pro-lock" >
-                                    <span class="ppseries-pro-badge" style="padding: 1px 10px;">PRO</span>
+                                    <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer" style="padding: 1px 10px;">PRO</a>
                                     <span class="tooltip-text">
                                         <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
                                         <i></i>
@@ -710,7 +710,7 @@ class PPS_Post_List_Box_Admin_UI {
                     <?php endif; ?>
                 <?php endif; ?>
                 <?php if ($pro_locked) : ?>
-                        <span class="ppseries-pro-badge">PRO</span>
+                        <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a>
                         <span class="tooltip-text">
                             <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
                             <i></i>

--- a/addons/post-navigation/includes/class-admin-ui.php
+++ b/addons/post-navigation/includes/class-admin-ui.php
@@ -437,7 +437,7 @@ class PPS_Series_Post_Navigation_Admin_UI
                 }
 
                 if ($pro_locked) : ?>
-                        <span class="ppseries-pro-badge">PRO</span>
+                        <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a>
                         <span class="tooltip-text">
                             <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
                             <i></i>

--- a/inc/settings/settings-page.php
+++ b/inc/settings/settings-page.php
@@ -208,7 +208,7 @@ function orgseries_option_page() {
 						<!-- PRO Features -->
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%series_slug%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%series_slug%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('Will output the slug of the series', 'organize-series'); ?></span>
                                 <i></i>
@@ -216,7 +216,7 @@ function orgseries_option_page() {
                         </span><br /><br />
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%series_id%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%series_id%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('Will output the ID of the series', 'organize-series'); ?></span>
                                 <i></i>
@@ -224,7 +224,7 @@ function orgseries_option_page() {
                         </span><br /><br />
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%post_author%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%post_author%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('Will output the author of the post', 'organize-series'); ?></span>
                                 <i></i>
@@ -232,7 +232,7 @@ function orgseries_option_page() {
                         </span><br /><br />
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%post_thumbnail%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%post_thumbnail%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('If the post has a feature-image then that image will be displayed', 'organize-series'); ?></span>
                                 <i></i>
@@ -240,7 +240,7 @@ function orgseries_option_page() {
                         </span><br /><br />
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%post_date%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%post_date%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('The date that a post was published', 'organize-series'); ?></span>
                                 <i></i>
@@ -248,7 +248,7 @@ function orgseries_option_page() {
                         </span><br /><br />
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%unpublished_post_title%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%unpublished_post_title%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('Will be replaced with the unpublished post title of a post in the series', 'organize-series'); ?></span>
                                 <i></i>
@@ -256,7 +256,7 @@ function orgseries_option_page() {
                         </span><br /><br />
                         
                         <span class="pp-tooltips-library" data-toggle="tooltip" data-placement="left">
-                            <strong>%total_posts_in_series_with_unpub%</strong> <?	if (!pp_series_is_pro_active()) { ?> <span class="ppseries-pro-badge">PRO</span> <? } ?>
+                            <strong>%total_posts_in_series_with_unpub%</strong> <?	if (!pp_series_is_pro_active()) { ?> <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a> <? } ?>
                             <span class="tooltip-text">
                                 <span><?php esc_html_e('Will display the total number of published and unpublished posts in a series', 'organize-series'); ?></span>
                                 <i></i>

--- a/inc/settings/tab-post-types.php
+++ b/inc/settings/tab-post-types.php
@@ -54,7 +54,7 @@ function series_cpt_settings_display() {
 									<input id="<?php echo $post_type; ?>" type="checkbox" <?php echo ($post_type === 'post') ? 'checked="checked"' : 'disabled="disabled"'; ?> />
 									<?php if ($post_type !== 'post') : ?>
 									<div class="ppseries-pro-lock">
-										<span class="ppseries-pro-badge">PRO</span>
+										<a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a>
 										<span class="tooltip-text">
 											<span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
 											<i></i>

--- a/inc/settings/tab-pro-features.php
+++ b/inc/settings/tab-pro-features.php
@@ -47,7 +47,7 @@ function series_addon_settings_display() {
 					<input type="checkbox" value="<?php echo $series_addon; ?>" id="ppseries-enable-<?php echo $series_addon; ?>" disabled="disabled" />
 						<span class="description"><?php echo $series_addon_option['description']; ?></span>
 					<div class="ppseries-pro-lock">
-						<span class="ppseries-pro-badge">PRO</span>
+						<a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer">PRO</a>
 						<span class="tooltip-text">
 							<span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
 							<i></i>

--- a/orgSeries-admin.css
+++ b/orgSeries-admin.css
@@ -385,6 +385,7 @@ input #seriesadd {
     margin-left: 5px;
     text-transform: uppercase;
     vertical-align: middle;
+    text-decoration: none;
 }
 
 /* End Pro feature overlay styles */


### PR DESCRIPTION
## What

- Turn every Free admin `PRO` badge into a link to the PublishPress Series banner.
- Open links in a new tab with the appropriate `noopener noreferrer` relationship.
- Preserve the existing badge styling for the new links.

## Why

Makes the Pro upsell badge actionable as requested in #1148.

## Checks

- `php -l` passed for all changed PHP files.
- `git diff --check`
- No test files added.