### PR TITLE
Indent dependent editor settings (#1149)

### DIFF
--- a/addons/post-details/assets/css/series-post-details-editor.css
+++ b/addons/post-details/assets/css/series-post-details-editor.css
@@ -496,6 +496,11 @@ tr[data-depends-on] {
     transition: opacity 0.2s ease;
 }
 
+.pps-series-post-details-editor-table tr[data-depends-on] > th,
+.pps-series-post-details-editor-table tr[data-depends-on] > td {
+    padding-left: 30px;
+}
+
 tr[data-depends-on]:not(.dependent-field-visible) {
     opacity: 0.3;
 }

--- a/addons/post-list-box/assets/css/post-list-box-editor.css
+++ b/addons/post-list-box/assets/css/post-list-box-editor.css
@@ -625,6 +625,11 @@ tr[data-depends-on] {
     transition: opacity 0.2s ease;
 }
 
+.pps-post-list-boxes-editor-table tr[data-depends-on] > th,
+.pps-post-list-boxes-editor-table tr[data-depends-on] > td {
+    padding-left: 30px;
+}
+
 tr[data-depends-on]:not(.dependent-field-visible) {
     opacity: 0.3;
 }

--- a/addons/post-navigation/assets/css/post-navigation-editor.css
+++ b/addons/post-navigation/assets/css/post-navigation-editor.css
@@ -117,6 +117,11 @@
     padding: 0 !important;
 }
 
+.pps-series-post-navigation-editor-table tr[data-depends-on] > th,
+.pps-series-post-navigation-editor-table tr[data-depends-on] > td {
+    padding-left: 30px;
+}
+
 .pps-field-separator {
     padding-top: 20px !important;
     padding-bottom: 10px !important;


### PR DESCRIPTION
## What

- Add a 30px left indent to dependent rows in the Post List Box editor.
- Add the same dependent-row indentation to the Post Details editor.
- Add the same dependent-row indentation to the Post Navigation editor.

## Why

Makes sub-settings visually follow their parent setting as requested in #1149.

## Checks

- `git diff --check`
- No test files added.