### PR TITLE
Translate custom template label in admin JavaScript (#1154)

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -40,7 +40,7 @@
     }
 
     // -------------------------------------------------------------
-    //   Token sidebar: only show when "Custom Template" is selected
+    //   Token sidebar: only show when the custom layout is selected
     // -------------------------------------------------------------
     function updateTokenSidebar() {
       var $sidebar = $('#ppseries-token-sidebar');
@@ -50,7 +50,7 @@
       var $activeSelect = $('.ppseries-settings-tab-content:not(.ppseries-hide-content) .ppseries-layout-select');
 
       if ($activeSelect.length) {
-        // Custom Template = empty value
+        // An empty value represents the custom layout.
         var isCustom = $activeSelect.val() === '';
         if (isCustom) {
           $sidebar.show();
@@ -130,7 +130,11 @@
           if (!response.success) return;
 
           $select.empty();
-          $select.append('<option value="">Custom Template</option>');
+          $select.append(
+            $('<option></option>')
+              .val('')
+              .text(settings.customTemplateLabel || '')
+          );
 
           $.each(response.data, function(i, item) {
             var $opt = $('<option></option>')

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -40,7 +40,7 @@
     }
 
     // -------------------------------------------------------------
-    //   Token sidebar: only show when the custom layout is selected
+    //   Token sidebar: only show when "Custom Template" is selected
     // -------------------------------------------------------------
     function updateTokenSidebar() {
       var $sidebar = $('#ppseries-token-sidebar');
@@ -50,7 +50,7 @@
       var $activeSelect = $('.ppseries-settings-tab-content:not(.ppseries-hide-content) .ppseries-layout-select');
 
       if ($activeSelect.length) {
-        // An empty value represents the custom layout.
+        // "Custom Template" = empty value
         var isCustom = $activeSelect.val() === '';
         if (isCustom) {
           $sidebar.show();
@@ -133,7 +133,7 @@
           $select.append(
             $('<option></option>')
               .val('')
-              .text(settings.customTemplateLabel || '')
+              .text(settings.customTemplateLabel || 'Custom Template')
           );
 
           $.each(response.data, function(i, item) {

--- a/orgSeries-admin.php
+++ b/orgSeries-admin.php
@@ -151,6 +151,7 @@ function orgSeries_admin_assets()
 		wp_localize_script( 'pps-admin-js', 'ppseriesSettings', [
 			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
 			'nonce'   => wp_create_nonce( 'ppseries_settings_nonce' ),
+			'customTemplateLabel' => __( 'Custom Template', 'organize-series' ),
 			'saved'   => [
 				'series_post_list_box_selection'  => isset( $org_opt['series_post_list_box_selection'] ) ? (int) $org_opt['series_post_list_box_selection'] : $default_post_list_box_selection,
 				'series_post_details_selection'   => isset( $org_opt['series_post_details_selection'] ) ? (int) $org_opt['series_post_details_selection'] : 0,


### PR DESCRIPTION
## What

- Localize the custom-template option label through `ppseriesSettings`.
- Build the option with jQuery so the localized label is inserted as text.
- Remove the hard-coded English label from `assets/js/admin.js`.

## Why

Makes the Custom Template label translatable as requested in #1154.

## Checks

- `php -l orgSeries-admin.php`
- `node --check assets/js/admin.js`
- `git diff --check`
- No test files added.