### PR TITLE
Show upgrade banner on layout screens

### DIFF
--- a/includes-core/PPSeriesCoreAdmin.php
+++ b/includes-core/PPSeriesCoreAdmin.php
@@ -18,7 +18,13 @@ class PPSeriesCoreAdmin {
                                         ['base' => 'term',      'id' => 'edit-series', 'taxonomy' => ppseries_get_series_slug() ],
                                         ['base' => 'edit-tags', 'id' => 'edit-series_group', 'taxonomy' => 'series_group' ],
                                         ['base' => 'term',      'id' => 'edit-series_group', 'taxonomy' => 'series_group' ],
-                                        ['base' => 'posts_page_manage-issues',      'id' => 'posts_page_manage-issues' ]
+                                        ['base' => 'posts_page_manage-issues',      'id' => 'posts_page_manage-issues' ],
+                                        ['base' => 'edit', 'id' => 'edit-pps_post_list_box', 'post_type' => 'pps_post_list_box'],
+                                        ['base' => 'post', 'id' => 'pps_post_list_box', 'post_type' => 'pps_post_list_box'],
+                                        ['base' => 'edit', 'id' => 'edit-pps_post_details', 'post_type' => 'pps_post_details'],
+                                        ['base' => 'post', 'id' => 'pps_post_details', 'post_type' => 'pps_post_details'],
+                                        ['base' => 'edit', 'id' => 'edit-pps_post_navigation', 'post_type' => 'pps_post_navigation'],
+                                        ['base' => 'post', 'id' => 'pps_post_navigation', 'post_type' => 'pps_post_navigation']
                                     ]
                                 ];
 


### PR DESCRIPTION
## Summary

- Add the Free upgrade banner to the Post List Boxes, Post Details, and Post Navigation admin screens.
- Match both the layout list and editor screens for each post type.

## Root cause

The shared top-notice configuration only listed the original Series admin screens. The three newer layout post types were not included, so the purple Free/Pro banner was not eligible to render there.

## Validation

- `php -l includes-core/PPSeriesCoreAdmin.php`
- `composer validate --no-check-publish`
- `git diff --check`

Fixes #1147.