### PR TITLE
Add welcome experience for Series (#1170)

### DIFF
--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -1,6 +1,8 @@
 .ppseries-welcome-panel {
     position: relative;
-    margin: 15px 0 20px;
+    /* The Screen Options and Help tabs float right. Stay below them. */
+    clear: both;
+    margin: 15px 20px 20px 0;
     padding: 24px 60px 24px 24px;
     background: #fff;
     border: 1px solid #c3c4c7;

--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -1,49 +1,32 @@
-.ppseries-welcome-panel {
+/* Thank-you notice */
+.ppseries-welcome-greeting {
     position: relative;
-    margin: 15px 0 20px;
-    padding: 24px 60px 24px 24px;
+    margin: 15px 0;
+    padding: 18px 50px;
     background: #fff;
-    border: 1px solid #c3c4c7;
+    border: 1px solid #e0e0e0;
     border-left: 4px solid #655997;
-    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+    border-radius: 4px;
+    text-align: center;
 }
 
-.ppseries-welcome-panel .ppseries-welcome-title {
-    margin: 0 0 8px;
-    font-size: 20px;
-    line-height: 1.3;
+.ppseries-welcome-greeting .ppseries-welcome-greeting-title {
+    margin: 0 0 4px;
+    font-size: 15px;
+    font-weight: 700;
+    color: #1d2327;
 }
 
-.ppseries-welcome-panel .ppseries-welcome-text {
-    margin: 0 0 16px;
-    max-width: 800px;
-    font-size: 14px;
-    color: #50575e;
+.ppseries-welcome-greeting .ppseries-welcome-greeting-text {
+    margin: 0;
+    font-size: 13px;
+    color: #646970;
 }
 
-.ppseries-welcome-panel .ppseries-welcome-actions {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 10px;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-upgrade {
-    margin-left: 6px;
-    font-weight: 600;
-    color: #655997;
-    text-decoration: none;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-upgrade:hover,
-.ppseries-welcome-panel .ppseries-welcome-upgrade:focus {
-    text-decoration: underline;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-dismiss {
+.ppseries-welcome-greeting .ppseries-welcome-dismiss {
     position: absolute;
-    top: 12px;
-    right: 12px;
+    top: 10px;
+    right: 10px;
     padding: 0;
     background: none;
     border: 0;
@@ -51,7 +34,258 @@
     cursor: pointer;
 }
 
-.ppseries-welcome-panel .ppseries-welcome-dismiss:hover,
-.ppseries-welcome-panel .ppseries-welcome-dismiss:focus {
+.ppseries-welcome-greeting .ppseries-welcome-dismiss:hover,
+.ppseries-welcome-greeting .ppseries-welcome-dismiss:focus {
     color: #d63638;
+}
+
+/* Get-started panel */
+.ppseries-welcome-panel {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 20px 0;
+    border: 1px solid #e0e0e0;
+    border-radius: 10px;
+    overflow: hidden;
+    background: #faf9f7;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-intro {
+    flex: 1 1 340px;
+    padding: 40px;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-eyebrow {
+    margin: 0 0 12px;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: #655997;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-title {
+    margin: 0 0 14px;
+    padding: 0;
+    font-size: 38px;
+    line-height: 1.15;
+    font-weight: 800;
+    color: #1d2327;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-text {
+    margin: 0 0 24px;
+    max-width: 420px;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #50575e;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-button {
+    display: inline-block;
+    padding: 12px 26px;
+    background: #655997;
+    border-radius: 6px;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 600;
+    text-decoration: none;
+    box-shadow: 0 6px 14px rgba(101, 89, 151, .25);
+}
+
+.ppseries-welcome-panel .ppseries-welcome-button:hover,
+.ppseries-welcome-panel .ppseries-welcome-button:focus {
+    background: #544a80;
+    color: #fff;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 26px 0 0;
+    padding: 0;
+    list-style: none;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-pills li {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0;
+    padding: 7px 14px;
+    background: #fff;
+    border: 1px solid #e6e2dc;
+    border-radius: 999px;
+    font-size: 12px;
+    color: #3c434a;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-pills .dashicons {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: #655997;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-links {
+    margin: 24px 0 0;
+    font-size: 13px;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-links a {
+    margin-right: 18px;
+    color: #655997;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-links a:hover,
+.ppseries-welcome-panel .ppseries-welcome-links a:focus {
+    text-decoration: underline;
+}
+
+/* Preview side */
+.ppseries-welcome-panel .ppseries-welcome-preview {
+    flex: 1 1 380px;
+    padding: 30px;
+    background: #f1ede7;
+}
+
+.ppseries-welcome-panel .ppseries-preview-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 18px;
+}
+
+.ppseries-welcome-panel .ppseries-preview-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: #8c8579;
+}
+
+.ppseries-welcome-panel .ppseries-preview-tabs {
+    display: flex;
+    padding: 3px;
+    background: #fff;
+    border-radius: 999px;
+}
+
+.ppseries-welcome-panel .ppseries-preview-tab {
+    padding: 6px 14px;
+    background: none;
+    border: 0;
+    border-radius: 999px;
+    font-size: 12px;
+    color: #50575e;
+    cursor: pointer;
+}
+
+.ppseries-welcome-panel .ppseries-preview-tab.is-active {
+    background: #1d2327;
+    color: #fff;
+}
+
+.ppseries-welcome-panel .ppseries-preview-pane {
+    display: none;
+}
+
+.ppseries-welcome-panel .ppseries-preview-pane.is-active {
+    display: block;
+}
+
+.ppseries-welcome-panel .ppseries-preview-card {
+    padding: 22px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, .06);
+}
+
+.ppseries-welcome-panel .ppseries-preview-card-title {
+    margin: 0 0 14px;
+    font-size: 16px;
+    font-weight: 700;
+    color: #1d2327;
+}
+
+.ppseries-welcome-panel .ppseries-preview-list {
+    margin: 0;
+    padding-left: 20px;
+    font-size: 13px;
+    color: #50575e;
+}
+
+.ppseries-welcome-panel .ppseries-preview-list li {
+    margin-bottom: 8px;
+}
+
+.ppseries-welcome-panel .ppseries-preview-list li.is-current {
+    font-weight: 700;
+    color: #655997;
+}
+
+.ppseries-welcome-panel .ppseries-preview-note {
+    margin: 0 0 16px;
+    padding: 12px 14px;
+    background: #f4f2fa;
+    border-left: 3px solid #655997;
+    border-radius: 4px;
+    font-size: 13px;
+    color: #3c434a;
+}
+
+.ppseries-welcome-panel .ppseries-preview-nav {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 16px;
+}
+
+.ppseries-welcome-panel .ppseries-preview-nav-item {
+    flex: 1;
+    padding: 12px 14px;
+    border: 1px solid #e6e2dc;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.ppseries-welcome-panel .ppseries-preview-nav-item.is-next {
+    text-align: right;
+}
+
+.ppseries-welcome-panel .ppseries-preview-nav-item small {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 11px;
+    font-weight: 400;
+    color: #8c8579;
+}
+
+.ppseries-welcome-panel .ppseries-preview-lines span {
+    display: block;
+    height: 8px;
+    margin-bottom: 10px;
+    background: #efefef;
+    border-radius: 4px;
+}
+
+.ppseries-welcome-panel .ppseries-preview-lines span.is-short {
+    width: 60%;
+}
+
+@media screen and (max-width: 782px) {
+    .ppseries-welcome-panel .ppseries-welcome-intro,
+    .ppseries-welcome-panel .ppseries-welcome-preview {
+        padding: 24px;
+    }
+
+    .ppseries-welcome-panel .ppseries-welcome-title {
+        font-size: 28px;
+    }
 }

--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -1,0 +1,61 @@
+.ppseries-welcome-panel {
+    position: relative;
+    margin: 15px 0 20px;
+    padding: 24px 60px 24px 24px;
+    background: #fff;
+    border: 1px solid #c3c4c7;
+    border-left: 4px solid #655997;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
+}
+
+.ppseries-welcome-panel .ppseries-welcome-title {
+    margin: 0 0 8px;
+    font-size: 20px;
+    line-height: 1.3;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-text {
+    margin: 0 0 16px;
+    max-width: 800px;
+    font-size: 14px;
+    color: #50575e;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-upgrade {
+    margin-left: 6px;
+    font-weight: 600;
+    color: #655997;
+    text-decoration: none;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-upgrade:hover,
+.ppseries-welcome-panel .ppseries-welcome-upgrade:focus {
+    text-decoration: underline;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-dismiss {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    padding: 0;
+    background: none;
+    border: 0;
+    color: #787c82;
+    cursor: pointer;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-dismiss:hover,
+.ppseries-welcome-panel .ppseries-welcome-dismiss:focus {
+    color: #d63638;
+}
+
+.ppseries-welcome-highlight {
+    box-shadow: 0 0 0 2px #655997;
+}

--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -55,7 +55,3 @@
 .ppseries-welcome-panel .ppseries-welcome-dismiss:focus {
     color: #d63638;
 }
-
-.ppseries-welcome-highlight {
-    box-shadow: 0 0 0 2px #655997;
-}

--- a/assets/css/welcome.css
+++ b/assets/css/welcome.css
@@ -1,32 +1,49 @@
-/* Thank-you notice */
-.ppseries-welcome-greeting {
+.ppseries-welcome-panel {
     position: relative;
-    margin: 15px 0;
-    padding: 18px 50px;
+    margin: 15px 0 20px;
+    padding: 24px 60px 24px 24px;
     background: #fff;
-    border: 1px solid #e0e0e0;
+    border: 1px solid #c3c4c7;
     border-left: 4px solid #655997;
-    border-radius: 4px;
-    text-align: center;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, .04);
 }
 
-.ppseries-welcome-greeting .ppseries-welcome-greeting-title {
-    margin: 0 0 4px;
-    font-size: 15px;
-    font-weight: 700;
-    color: #1d2327;
+.ppseries-welcome-panel .ppseries-welcome-title {
+    margin: 0 0 8px;
+    font-size: 20px;
+    line-height: 1.3;
 }
 
-.ppseries-welcome-greeting .ppseries-welcome-greeting-text {
-    margin: 0;
-    font-size: 13px;
-    color: #646970;
+.ppseries-welcome-panel .ppseries-welcome-text {
+    margin: 0 0 16px;
+    max-width: 800px;
+    font-size: 14px;
+    color: #50575e;
 }
 
-.ppseries-welcome-greeting .ppseries-welcome-dismiss {
+.ppseries-welcome-panel .ppseries-welcome-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-upgrade {
+    margin-left: 6px;
+    font-weight: 600;
+    color: #655997;
+    text-decoration: none;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-upgrade:hover,
+.ppseries-welcome-panel .ppseries-welcome-upgrade:focus {
+    text-decoration: underline;
+}
+
+.ppseries-welcome-panel .ppseries-welcome-dismiss {
     position: absolute;
-    top: 10px;
-    right: 10px;
+    top: 12px;
+    right: 12px;
     padding: 0;
     background: none;
     border: 0;
@@ -34,258 +51,7 @@
     cursor: pointer;
 }
 
-.ppseries-welcome-greeting .ppseries-welcome-dismiss:hover,
-.ppseries-welcome-greeting .ppseries-welcome-dismiss:focus {
+.ppseries-welcome-panel .ppseries-welcome-dismiss:hover,
+.ppseries-welcome-panel .ppseries-welcome-dismiss:focus {
     color: #d63638;
-}
-
-/* Get-started panel */
-.ppseries-welcome-panel {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 20px 0;
-    border: 1px solid #e0e0e0;
-    border-radius: 10px;
-    overflow: hidden;
-    background: #faf9f7;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-intro {
-    flex: 1 1 340px;
-    padding: 40px;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-eyebrow {
-    margin: 0 0 12px;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: .12em;
-    text-transform: uppercase;
-    color: #655997;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-title {
-    margin: 0 0 14px;
-    padding: 0;
-    font-size: 38px;
-    line-height: 1.15;
-    font-weight: 800;
-    color: #1d2327;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-text {
-    margin: 0 0 24px;
-    max-width: 420px;
-    font-size: 14px;
-    line-height: 1.6;
-    color: #50575e;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-button {
-    display: inline-block;
-    padding: 12px 26px;
-    background: #655997;
-    border-radius: 6px;
-    color: #fff;
-    font-size: 15px;
-    font-weight: 600;
-    text-decoration: none;
-    box-shadow: 0 6px 14px rgba(101, 89, 151, .25);
-}
-
-.ppseries-welcome-panel .ppseries-welcome-button:hover,
-.ppseries-welcome-panel .ppseries-welcome-button:focus {
-    background: #544a80;
-    color: #fff;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-pills {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin: 26px 0 0;
-    padding: 0;
-    list-style: none;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-pills li {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin: 0;
-    padding: 7px 14px;
-    background: #fff;
-    border: 1px solid #e6e2dc;
-    border-radius: 999px;
-    font-size: 12px;
-    color: #3c434a;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-pills .dashicons {
-    font-size: 16px;
-    width: 16px;
-    height: 16px;
-    color: #655997;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-links {
-    margin: 24px 0 0;
-    font-size: 13px;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-links a {
-    margin-right: 18px;
-    color: #655997;
-    text-decoration: none;
-    font-weight: 600;
-}
-
-.ppseries-welcome-panel .ppseries-welcome-links a:hover,
-.ppseries-welcome-panel .ppseries-welcome-links a:focus {
-    text-decoration: underline;
-}
-
-/* Preview side */
-.ppseries-welcome-panel .ppseries-welcome-preview {
-    flex: 1 1 380px;
-    padding: 30px;
-    background: #f1ede7;
-}
-
-.ppseries-welcome-panel .ppseries-preview-head {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-bottom: 18px;
-}
-
-.ppseries-welcome-panel .ppseries-preview-label {
-    font-size: 11px;
-    font-weight: 700;
-    letter-spacing: .12em;
-    text-transform: uppercase;
-    color: #8c8579;
-}
-
-.ppseries-welcome-panel .ppseries-preview-tabs {
-    display: flex;
-    padding: 3px;
-    background: #fff;
-    border-radius: 999px;
-}
-
-.ppseries-welcome-panel .ppseries-preview-tab {
-    padding: 6px 14px;
-    background: none;
-    border: 0;
-    border-radius: 999px;
-    font-size: 12px;
-    color: #50575e;
-    cursor: pointer;
-}
-
-.ppseries-welcome-panel .ppseries-preview-tab.is-active {
-    background: #1d2327;
-    color: #fff;
-}
-
-.ppseries-welcome-panel .ppseries-preview-pane {
-    display: none;
-}
-
-.ppseries-welcome-panel .ppseries-preview-pane.is-active {
-    display: block;
-}
-
-.ppseries-welcome-panel .ppseries-preview-card {
-    padding: 22px;
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 6px 18px rgba(0, 0, 0, .06);
-}
-
-.ppseries-welcome-panel .ppseries-preview-card-title {
-    margin: 0 0 14px;
-    font-size: 16px;
-    font-weight: 700;
-    color: #1d2327;
-}
-
-.ppseries-welcome-panel .ppseries-preview-list {
-    margin: 0;
-    padding-left: 20px;
-    font-size: 13px;
-    color: #50575e;
-}
-
-.ppseries-welcome-panel .ppseries-preview-list li {
-    margin-bottom: 8px;
-}
-
-.ppseries-welcome-panel .ppseries-preview-list li.is-current {
-    font-weight: 700;
-    color: #655997;
-}
-
-.ppseries-welcome-panel .ppseries-preview-note {
-    margin: 0 0 16px;
-    padding: 12px 14px;
-    background: #f4f2fa;
-    border-left: 3px solid #655997;
-    border-radius: 4px;
-    font-size: 13px;
-    color: #3c434a;
-}
-
-.ppseries-welcome-panel .ppseries-preview-nav {
-    display: flex;
-    gap: 10px;
-    margin-bottom: 16px;
-}
-
-.ppseries-welcome-panel .ppseries-preview-nav-item {
-    flex: 1;
-    padding: 12px 14px;
-    border: 1px solid #e6e2dc;
-    border-radius: 6px;
-    font-size: 13px;
-    font-weight: 600;
-    color: #1d2327;
-}
-
-.ppseries-welcome-panel .ppseries-preview-nav-item.is-next {
-    text-align: right;
-}
-
-.ppseries-welcome-panel .ppseries-preview-nav-item small {
-    display: block;
-    margin-bottom: 4px;
-    font-size: 11px;
-    font-weight: 400;
-    color: #8c8579;
-}
-
-.ppseries-welcome-panel .ppseries-preview-lines span {
-    display: block;
-    height: 8px;
-    margin-bottom: 10px;
-    background: #efefef;
-    border-radius: 4px;
-}
-
-.ppseries-welcome-panel .ppseries-preview-lines span.is-short {
-    width: 60%;
-}
-
-@media screen and (max-width: 782px) {
-    .ppseries-welcome-panel .ppseries-welcome-intro,
-    .ppseries-welcome-panel .ppseries-welcome-preview {
-        padding: 24px;
-    }
-
-    .ppseries-welcome-panel .ppseries-welcome-title {
-        font-size: 28px;
-    }
 }

--- a/assets/js/welcome.js
+++ b/assets/js/welcome.js
@@ -3,29 +3,19 @@
     'use strict';
 
     $(function () {
-        var $greeting = $('.ppseries-welcome-greeting');
         var $panel = $('.ppseries-welcome-panel');
 
-        $greeting.on('click', '.ppseries-welcome-dismiss', function () {
-            $greeting.slideUp(200);
+        if (!$panel.length) {
+            return;
+        }
+
+        $panel.on('click', '.ppseries-welcome-dismiss', function () {
+            $panel.slideUp(200);
 
             $.post(ppseriesWelcome.ajaxUrl, {
                 action: 'ppseries_dismiss_welcome_panel',
                 nonce: ppseriesWelcome.nonce
             });
-        });
-
-        $panel.on('click', '.ppseries-preview-tab', function () {
-            var $tab = $(this);
-            var target = $tab.data('preview');
-
-            $panel.find('.ppseries-preview-tab')
-                .removeClass('is-active')
-                .attr('aria-selected', 'false');
-            $tab.addClass('is-active').attr('aria-selected', 'true');
-
-            $panel.find('.ppseries-preview-pane').removeClass('is-active');
-            $panel.find('[data-preview-pane="' + target + '"]').addClass('is-active');
         });
     });
 })(jQuery);

--- a/assets/js/welcome.js
+++ b/assets/js/welcome.js
@@ -3,19 +3,29 @@
     'use strict';
 
     $(function () {
+        var $greeting = $('.ppseries-welcome-greeting');
         var $panel = $('.ppseries-welcome-panel');
 
-        if (!$panel.length) {
-            return;
-        }
-
-        $panel.on('click', '.ppseries-welcome-dismiss', function () {
-            $panel.slideUp(200);
+        $greeting.on('click', '.ppseries-welcome-dismiss', function () {
+            $greeting.slideUp(200);
 
             $.post(ppseriesWelcome.ajaxUrl, {
                 action: 'ppseries_dismiss_welcome_panel',
                 nonce: ppseriesWelcome.nonce
             });
+        });
+
+        $panel.on('click', '.ppseries-preview-tab', function () {
+            var $tab = $(this);
+            var target = $tab.data('preview');
+
+            $panel.find('.ppseries-preview-tab')
+                .removeClass('is-active')
+                .attr('aria-selected', 'false');
+            $tab.addClass('is-active').attr('aria-selected', 'true');
+
+            $panel.find('.ppseries-preview-pane').removeClass('is-active');
+            $panel.find('[data-preview-pane="' + target + '"]').addClass('is-active');
         });
     });
 })(jQuery);

--- a/assets/js/welcome.js
+++ b/assets/js/welcome.js
@@ -1,0 +1,39 @@
+/* global jQuery, ppseriesWelcome */
+(function ($) {
+    'use strict';
+
+    $(function () {
+        var $panel = $('.ppseries-welcome-panel');
+
+        if (!$panel.length) {
+            return;
+        }
+
+        $panel.on('click', '.ppseries-welcome-add', function () {
+            var $field = $('#tag-name');
+
+            if (!$field.length) {
+                return;
+            }
+
+            $('html, body').animate({
+                scrollTop: $field.offset().top - 80
+            }, 300);
+
+            $field.trigger('focus').addClass('ppseries-welcome-highlight');
+
+            window.setTimeout(function () {
+                $field.removeClass('ppseries-welcome-highlight');
+            }, 2000);
+        });
+
+        $panel.on('click', '.ppseries-welcome-dismiss', function () {
+            $panel.slideUp(200);
+
+            $.post(ppseriesWelcome.ajaxUrl, {
+                action: 'ppseries_dismiss_welcome_panel',
+                nonce: ppseriesWelcome.nonce
+            });
+        });
+    });
+})(jQuery);

--- a/assets/js/welcome.js
+++ b/assets/js/welcome.js
@@ -9,24 +9,6 @@
             return;
         }
 
-        $panel.on('click', '.ppseries-welcome-add', function () {
-            var $field = $('#tag-name');
-
-            if (!$field.length) {
-                return;
-            }
-
-            $('html, body').animate({
-                scrollTop: $field.offset().top - 80
-            }, 300);
-
-            $field.trigger('focus').addClass('ppseries-welcome-highlight');
-
-            window.setTimeout(function () {
-                $field.removeClass('ppseries-welcome-highlight');
-            }, 2000);
-        });
-
         $panel.on('click', '.ppseries-welcome-dismiss', function () {
             $panel.slideUp(200);
 

--- a/inc/settings/settings-page.php
+++ b/inc/settings/settings-page.php
@@ -17,6 +17,9 @@ function orgseries_option_page() {
 		<div class="icon32" id="icon-options-general"><br /></div>
 		<h2><?php esc_html_e('PublishPress Series Plugin Options', 'organize-series'); ?></h2>
 	<?php
+	do_action('publishpress_series_settings_after_title');
+	?>
+	<?php
     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo $org_update_message;
 	update_option('orgseries_update_message','');

--- a/inc/settings/settings-page.php
+++ b/inc/settings/settings-page.php
@@ -17,9 +17,6 @@ function orgseries_option_page() {
 		<div class="icon32" id="icon-options-general"><br /></div>
 		<h2><?php esc_html_e('PublishPress Series Plugin Options', 'organize-series'); ?></h2>
 	<?php
-	do_action('publishpress_series_settings_after_title');
-	?>
-	<?php
     // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo $org_update_message;
 	update_option('orgseries_update_message','');

--- a/inc/welcome/welcome-panel.php
+++ b/inc/welcome/welcome-panel.php
@@ -2,8 +2,9 @@
 /**
  * Welcome experience for PublishPress Series.
  *
- * After activation the user goes to the Series settings page. A welcome panel
- * on that page shows the first steps: create a series, read the documentation.
+ * After activation the user goes to the Series screen. While the site has no
+ * series, a welcome panel on that screen shows the first steps: create a
+ * series and read the documentation.
  *
  * @package Publishpress Series
  */
@@ -17,23 +18,29 @@ define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_panel_dismissed');
 
 add_action('admin_init', 'ppseries_welcome_redirect');
 add_action('admin_enqueue_scripts', 'ppseries_welcome_assets');
-add_action('publishpress_series_settings_after_title', 'ppseries_welcome_panel');
+add_action('admin_notices', 'ppseries_welcome_panel');
 add_action('wp_ajax_ppseries_dismiss_welcome_panel', 'ppseries_dismiss_welcome_panel');
 
 /**
- * Tell if the current screen is the Series settings page.
+ * Tell if the current screen is the Series list screen.
  *
  * @return bool
  */
-function ppseries_is_series_settings_screen()
+function ppseries_is_series_list_screen()
 {
-    $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
+    global $pagenow;
 
-    return 'orgseries_options_page' === $page;
+    if ('edit-tags.php' !== $pagenow) {
+        return false;
+    }
+
+    $taxonomy = isset($_GET['taxonomy']) ? sanitize_key(wp_unslash($_GET['taxonomy'])) : '';
+
+    return $taxonomy === ppseries_get_series_slug();
 }
 
 /**
- * Send the user to the Series settings page one time after activation.
+ * Send the user to the Series screen one time after activation.
  */
 function ppseries_welcome_redirect()
 {
@@ -52,7 +59,7 @@ function ppseries_welcome_redirect()
         return;
     }
 
-    wp_safe_redirect(ppseries_series_settings_page());
+    wp_safe_redirect(admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug()));
     exit;
 }
 
@@ -61,7 +68,7 @@ function ppseries_welcome_redirect()
  */
 function ppseries_welcome_assets()
 {
-    if (!ppseries_is_series_settings_screen() || !ppseries_welcome_panel_is_visible()) {
+    if (!ppseries_is_series_list_screen() || !ppseries_welcome_panel_is_visible()) {
         return;
     }
 
@@ -125,11 +132,9 @@ function ppseries_welcome_series_count()
  */
 function ppseries_welcome_panel()
 {
-    if (!ppseries_welcome_panel_is_visible()) {
+    if (!ppseries_is_series_list_screen() || !ppseries_welcome_panel_is_visible()) {
         return;
     }
-
-    $series_url = admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug());
 
     ?>
     <div class="ppseries-welcome-panel">
@@ -142,14 +147,10 @@ function ppseries_welcome_panel()
                 <?php esc_html_e('Welcome! Create your first series', 'organize-series'); ?>
             </h2>
             <p class="ppseries-welcome-text">
-                <?php esc_html_e('A series groups your posts together and shows your readers the reading order. Start with the Series screen to create your first series, then add posts to it.', 'organize-series'); ?>
+                <?php esc_html_e('A series groups your posts together and shows your readers the reading order. Use the Add New Series form on this page to create your first series, then add posts to it.', 'organize-series'); ?>
             </p>
 
             <div class="ppseries-welcome-actions">
-                <a class="button button-primary" href="<?php echo esc_url($series_url); ?>">
-                    <?php esc_html_e('Create Your First Series', 'organize-series'); ?>
-                </a>
-
                 <a class="button" href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">
                     <?php esc_html_e('View Documentation', 'organize-series'); ?>
                 </a>

--- a/inc/welcome/welcome-panel.php
+++ b/inc/welcome/welcome-panel.php
@@ -2,9 +2,8 @@
 /**
  * Welcome experience for PublishPress Series.
  *
- * After activation the user goes to the Series screen. A welcome panel on that
- * screen shows the first steps: create a series, read the documentation and
- * open the settings.
+ * After activation the user goes to the Series settings page. A welcome panel
+ * on that page shows the first steps: create a series, read the documentation.
  *
  * @package Publishpress Series
  */
@@ -18,29 +17,23 @@ define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_panel_dismissed');
 
 add_action('admin_init', 'ppseries_welcome_redirect');
 add_action('admin_enqueue_scripts', 'ppseries_welcome_assets');
-add_action('admin_notices', 'ppseries_welcome_panel');
+add_action('publishpress_series_settings_after_title', 'ppseries_welcome_panel');
 add_action('wp_ajax_ppseries_dismiss_welcome_panel', 'ppseries_dismiss_welcome_panel');
 
 /**
- * Tell if the current screen is the Series taxonomy list screen.
+ * Tell if the current screen is the Series settings page.
  *
  * @return bool
  */
-function ppseries_is_series_list_screen()
+function ppseries_is_series_settings_screen()
 {
-    global $pagenow;
+    $page = isset($_GET['page']) ? sanitize_key(wp_unslash($_GET['page'])) : '';
 
-    if ('edit-tags.php' !== $pagenow) {
-        return false;
-    }
-
-    $taxonomy = isset($_GET['taxonomy']) ? sanitize_key(wp_unslash($_GET['taxonomy'])) : '';
-
-    return $taxonomy === ppseries_get_series_slug();
+    return 'orgseries_options_page' === $page;
 }
 
 /**
- * Send the user to the Series screen one time after activation.
+ * Send the user to the Series settings page one time after activation.
  */
 function ppseries_welcome_redirect()
 {
@@ -59,7 +52,7 @@ function ppseries_welcome_redirect()
         return;
     }
 
-    wp_safe_redirect(admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug()));
+    wp_safe_redirect(ppseries_series_settings_page());
     exit;
 }
 
@@ -68,7 +61,7 @@ function ppseries_welcome_redirect()
  */
 function ppseries_welcome_assets()
 {
-    if (!ppseries_is_series_list_screen() || !ppseries_welcome_panel_is_visible()) {
+    if (!ppseries_is_series_settings_screen() || !ppseries_welcome_panel_is_visible()) {
         return;
     }
 
@@ -127,24 +120,24 @@ function ppseries_welcome_series_count()
 }
 
 /**
- * Show the welcome panel on the Series screen.
+ * Show the welcome panel on the Series settings page.
  */
 function ppseries_welcome_panel()
 {
-    if (!ppseries_is_series_list_screen() || !ppseries_welcome_panel_is_visible()) {
+    if (!ppseries_welcome_panel_is_visible()) {
         return;
     }
 
-    $has_series   = ppseries_welcome_series_count() > 0;
-    $settings_url = ppseries_series_settings_page();
+    $has_series = ppseries_welcome_series_count() > 0;
+    $series_url = admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug());
 
     $title = $has_series
         ? esc_html__('Welcome to PublishPress Series', 'organize-series')
         : esc_html__('Welcome! Create your first series', 'organize-series');
 
     $description = $has_series
-        ? esc_html__('A series groups your posts together and shows your readers the reading order. Use the form on this screen to add another series, or change how your series look in the settings.', 'organize-series')
-        : esc_html__('A series groups your posts together and shows your readers the reading order. Add a name in the form on this screen to create your first series, then add posts to it.', 'organize-series');
+        ? esc_html__('A series groups your posts together and shows your readers the reading order. Use the settings on this page to change how your series look, or go to the Series screen to add more series.', 'organize-series')
+        : esc_html__('A series groups your posts together and shows your readers the reading order. Start with the Series screen to create your first series, then add posts to it.', 'organize-series');
 
     ?>
     <div class="ppseries-welcome-panel">
@@ -157,16 +150,12 @@ function ppseries_welcome_panel()
             <p class="ppseries-welcome-text"><?php echo $description; ?></p>
 
             <div class="ppseries-welcome-actions">
-                <button type="button" class="button button-primary ppseries-welcome-add">
+                <a class="button button-primary" href="<?php echo esc_url($series_url); ?>">
                     <?php
                     echo $has_series
-                        ? esc_html__('Add New Series', 'organize-series')
+                        ? esc_html__('Manage Your Series', 'organize-series')
                         : esc_html__('Create Your First Series', 'organize-series');
                     ?>
-                </button>
-
-                <a class="button" href="<?php echo esc_url($settings_url); ?>">
-                    <?php esc_html_e('Series Settings', 'organize-series'); ?>
                 </a>
 
                 <a class="button" href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">

--- a/inc/welcome/welcome-panel.php
+++ b/inc/welcome/welcome-panel.php
@@ -101,7 +101,8 @@ function ppseries_welcome_panel_is_visible()
         return false;
     }
 
-    return true;
+    // The panel is an empty state. It stops when the site has series.
+    return ppseries_welcome_series_count() < 1;
 }
 
 /**
@@ -128,16 +129,7 @@ function ppseries_welcome_panel()
         return;
     }
 
-    $has_series = ppseries_welcome_series_count() > 0;
     $series_url = admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug());
-
-    $title = $has_series
-        ? esc_html__('Welcome to PublishPress Series', 'organize-series')
-        : esc_html__('Welcome! Create your first series', 'organize-series');
-
-    $description = $has_series
-        ? esc_html__('A series groups your posts together and shows your readers the reading order. Use the settings on this page to change how your series look, or go to the Series screen to add more series.', 'organize-series')
-        : esc_html__('A series groups your posts together and shows your readers the reading order. Start with the Series screen to create your first series, then add posts to it.', 'organize-series');
 
     ?>
     <div class="ppseries-welcome-panel">
@@ -146,16 +138,16 @@ function ppseries_welcome_panel()
         </button>
 
         <div class="ppseries-welcome-content">
-            <h2 class="ppseries-welcome-title"><?php echo $title; ?></h2>
-            <p class="ppseries-welcome-text"><?php echo $description; ?></p>
+            <h2 class="ppseries-welcome-title">
+                <?php esc_html_e('Welcome! Create your first series', 'organize-series'); ?>
+            </h2>
+            <p class="ppseries-welcome-text">
+                <?php esc_html_e('A series groups your posts together and shows your readers the reading order. Start with the Series screen to create your first series, then add posts to it.', 'organize-series'); ?>
+            </p>
 
             <div class="ppseries-welcome-actions">
                 <a class="button button-primary" href="<?php echo esc_url($series_url); ?>">
-                    <?php
-                    echo $has_series
-                        ? esc_html__('Manage Your Series', 'organize-series')
-                        : esc_html__('Create Your First Series', 'organize-series');
-                    ?>
+                    <?php esc_html_e('Create Your First Series', 'organize-series'); ?>
                 </a>
 
                 <a class="button" href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">

--- a/inc/welcome/welcome-panel.php
+++ b/inc/welcome/welcome-panel.php
@@ -2,9 +2,8 @@
 /**
  * Welcome experience for PublishPress Series.
  *
- * After activation the user goes to the Series settings page. That page shows
- * a thank-you notice and, while the site has no series, a get-started panel
- * with a preview of what a series looks like on the site.
+ * After activation the user goes to the Series settings page. A welcome panel
+ * on that page shows the first steps: create a series, read the documentation.
  *
  * @package Publishpress Series
  */
@@ -14,12 +13,10 @@ if (!defined('ABSPATH')) {
 }
 
 define('PPSERIES_WELCOME_REDIRECT_OPTION', 'ppseries_do_welcome_redirect');
-define('PPSERIES_WELCOME_GREETING_OPTION', 'ppseries_show_welcome_greeting');
-define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_greeting_dismissed');
+define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_panel_dismissed');
 
 add_action('admin_init', 'ppseries_welcome_redirect');
 add_action('admin_enqueue_scripts', 'ppseries_welcome_assets');
-add_action('publishpress_series_settings_after_title', 'ppseries_welcome_greeting');
 add_action('publishpress_series_settings_after_title', 'ppseries_welcome_panel');
 add_action('wp_ajax_ppseries_dismiss_welcome_panel', 'ppseries_dismiss_welcome_panel');
 
@@ -60,15 +57,11 @@ function ppseries_welcome_redirect()
 }
 
 /**
- * Load the styles and the script of the welcome experience.
+ * Load the styles and the script of the welcome panel.
  */
 function ppseries_welcome_assets()
 {
-    if (!ppseries_is_series_settings_screen() || !current_user_can('manage_publishpress_series')) {
-        return;
-    }
-
-    if (!ppseries_welcome_greeting_is_visible() && ppseries_welcome_series_count() > 0) {
+    if (!ppseries_is_series_settings_screen() || !ppseries_welcome_panel_is_visible()) {
         return;
     }
 
@@ -94,26 +87,21 @@ function ppseries_welcome_assets()
 }
 
 /**
- * Tell if the thank-you notice must be shown to the current user.
+ * Tell if the welcome panel must be shown to the current user.
  *
  * @return bool
  */
-function ppseries_welcome_greeting_is_visible()
+function ppseries_welcome_panel_is_visible()
 {
     if (!current_user_can('manage_publishpress_series')) {
         return false;
     }
 
-    if (!get_option(PPSERIES_WELCOME_GREETING_OPTION)) {
+    if (get_user_meta(get_current_user_id(), PPSERIES_WELCOME_DISMISSED_META, true)) {
         return false;
     }
 
-    // The greeting is only for the start. It stops when the site has series.
-    if (ppseries_welcome_series_count() > 0) {
-        return false;
-    }
-
-    return !get_user_meta(get_current_user_id(), PPSERIES_WELCOME_DISMISSED_META, true);
+    return true;
 }
 
 /**
@@ -132,140 +120,53 @@ function ppseries_welcome_series_count()
 }
 
 /**
- * Show the thank-you notice after activation.
- */
-function ppseries_welcome_greeting()
-{
-    if (!ppseries_welcome_greeting_is_visible()) {
-        return;
-    }
-
-    ?>
-    <div class="ppseries-welcome-greeting">
-        <button type="button" class="ppseries-welcome-dismiss" aria-label="<?php esc_attr_e('Dismiss this notice', 'organize-series'); ?>">
-            <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
-        </button>
-        <p class="ppseries-welcome-greeting-title">
-            <span aria-hidden="true">&#128075;</span>
-            <?php esc_html_e('Thanks for installing PublishPress Series!', 'organize-series'); ?>
-        </p>
-        <p class="ppseries-welcome-greeting-text">
-            <?php esc_html_e('You are all set. Create your first series to get started.', 'organize-series'); ?>
-        </p>
-    </div>
-    <?php
-}
-
-/**
- * Show the get-started panel while the site has no series.
+ * Show the welcome panel on the Series settings page.
  */
 function ppseries_welcome_panel()
 {
-    if (!current_user_can('manage_publishpress_series') || ppseries_welcome_series_count() > 0) {
+    if (!ppseries_welcome_panel_is_visible()) {
         return;
     }
 
+    $has_series = ppseries_welcome_series_count() > 0;
     $series_url = admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug());
+
+    $title = $has_series
+        ? esc_html__('Welcome to PublishPress Series', 'organize-series')
+        : esc_html__('Welcome! Create your first series', 'organize-series');
+
+    $description = $has_series
+        ? esc_html__('A series groups your posts together and shows your readers the reading order. Use the settings on this page to change how your series look, or go to the Series screen to add more series.', 'organize-series')
+        : esc_html__('A series groups your posts together and shows your readers the reading order. Start with the Series screen to create your first series, then add posts to it.', 'organize-series');
 
     ?>
     <div class="ppseries-welcome-panel">
-        <div class="ppseries-welcome-intro">
-            <p class="ppseries-welcome-eyebrow"><?php esc_html_e('Get started', 'organize-series'); ?></p>
-            <h2 class="ppseries-welcome-title">
-                <?php esc_html_e('Your series live here.', 'organize-series'); ?>
-            </h2>
-            <p class="ppseries-welcome-text">
-                <?php esc_html_e('Group related posts into a series. Your readers get a post list, the part number, and links to the next and previous post. No code required.', 'organize-series'); ?>
-            </p>
+        <button type="button" class="ppseries-welcome-dismiss" aria-label="<?php esc_attr_e('Dismiss this panel', 'organize-series'); ?>">
+            <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+        </button>
 
-            <a class="ppseries-welcome-button" href="<?php echo esc_url($series_url); ?>">
-                <?php esc_html_e('Create your first series', 'organize-series'); ?>
-            </a>
+        <div class="ppseries-welcome-content">
+            <h2 class="ppseries-welcome-title"><?php echo $title; ?></h2>
+            <p class="ppseries-welcome-text"><?php echo $description; ?></p>
 
-            <ul class="ppseries-welcome-pills">
-                <li><span class="dashicons dashicons-list-view" aria-hidden="true"></span><?php esc_html_e('Automatic post list', 'organize-series'); ?></li>
-                <li><span class="dashicons dashicons-info-outline" aria-hidden="true"></span><?php esc_html_e('Part 2 of 5 details', 'organize-series'); ?></li>
-                <li><span class="dashicons dashicons-leftright" aria-hidden="true"></span><?php esc_html_e('Next and previous links', 'organize-series'); ?></li>
-            </ul>
-
-            <p class="ppseries-welcome-links">
-                <a href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">
-                    <?php esc_html_e('View documentation', 'organize-series'); ?>
+            <div class="ppseries-welcome-actions">
+                <a class="button button-primary" href="<?php echo esc_url($series_url); ?>">
+                    <?php
+                    echo $has_series
+                        ? esc_html__('Manage Your Series', 'organize-series')
+                        : esc_html__('Create Your First Series', 'organize-series');
+                    ?>
                 </a>
+
+                <a class="button" href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">
+                    <?php esc_html_e('View Documentation', 'organize-series'); ?>
+                </a>
+
                 <?php if (!pp_series_is_pro_active()) : ?>
-                    <a href="https://publishpress.com/links/series-banner" target="_blank" rel="noopener noreferrer">
+                    <a class="ppseries-welcome-upgrade" href="https://publishpress.com/links/series-banner" target="_blank" rel="noopener noreferrer">
                         <?php esc_html_e('Upgrade to Pro', 'organize-series'); ?>
                     </a>
                 <?php endif; ?>
-            </p>
-        </div>
-
-        <div class="ppseries-welcome-preview">
-            <div class="ppseries-preview-head">
-                <span class="ppseries-preview-label"><?php esc_html_e('Preview', 'organize-series'); ?></span>
-                <div class="ppseries-preview-tabs" role="tablist">
-                    <button type="button" class="ppseries-preview-tab is-active" data-preview="list" role="tab" aria-selected="true">
-                        <?php esc_html_e('Post List', 'organize-series'); ?>
-                    </button>
-                    <button type="button" class="ppseries-preview-tab" data-preview="details" role="tab" aria-selected="false">
-                        <?php esc_html_e('Post Details', 'organize-series'); ?>
-                    </button>
-                    <button type="button" class="ppseries-preview-tab" data-preview="navigation" role="tab" aria-selected="false">
-                        <?php esc_html_e('Navigation', 'organize-series'); ?>
-                    </button>
-                </div>
-            </div>
-
-            <div class="ppseries-preview-stage">
-                <div class="ppseries-preview-pane is-active" data-preview-pane="list">
-                    <div class="ppseries-preview-card">
-                        <p class="ppseries-preview-card-title"><?php esc_html_e('The WordPress Guide', 'organize-series'); ?></p>
-                        <ol class="ppseries-preview-list">
-                            <li><?php esc_html_e('Install WordPress', 'organize-series'); ?></li>
-                            <li class="is-current"><?php esc_html_e('Choose a theme', 'organize-series'); ?></li>
-                            <li><?php esc_html_e('Add your first posts', 'organize-series'); ?></li>
-                            <li><?php esc_html_e('Set up the menus', 'organize-series'); ?></li>
-                            <li><?php esc_html_e('Go live', 'organize-series'); ?></li>
-                        </ol>
-                    </div>
-                </div>
-
-                <div class="ppseries-preview-pane" data-preview-pane="details">
-                    <div class="ppseries-preview-card">
-                        <p class="ppseries-preview-note">
-                            <?php
-                            printf(
-                                /* translators: 1: part number, 2: total posts, 3: series name */
-                                esc_html__('This entry is part %1$s of %2$s in the series %3$s', 'organize-series'),
-                                '<strong>2</strong>',
-                                '<strong>5</strong>',
-                                '<em>' . esc_html__('The WordPress Guide', 'organize-series') . '</em>'
-                            );
-                            ?>
-                        </p>
-                        <div class="ppseries-preview-lines">
-                            <span></span><span></span><span class="is-short"></span>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="ppseries-preview-pane" data-preview-pane="navigation">
-                    <div class="ppseries-preview-card">
-                        <div class="ppseries-preview-nav">
-                            <span class="ppseries-preview-nav-item">
-                                <small><?php esc_html_e('Previous in series', 'organize-series'); ?></small>
-                                <?php esc_html_e('Install WordPress', 'organize-series'); ?>
-                            </span>
-                            <span class="ppseries-preview-nav-item is-next">
-                                <small><?php esc_html_e('Next in series', 'organize-series'); ?></small>
-                                <?php esc_html_e('Add your first posts', 'organize-series'); ?>
-                            </span>
-                        </div>
-                        <div class="ppseries-preview-lines">
-                            <span></span><span class="is-short"></span>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
     </div>
@@ -273,7 +174,7 @@ function ppseries_welcome_panel()
 }
 
 /**
- * Save the dismissal of the thank-you notice for the current user.
+ * Save the dismissal of the welcome panel for the current user.
  */
 function ppseries_dismiss_welcome_panel()
 {

--- a/inc/welcome/welcome-panel.php
+++ b/inc/welcome/welcome-panel.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Welcome experience for PublishPress Series.
+ *
+ * After activation the user goes to the Series screen. A welcome panel on that
+ * screen shows the first steps: create a series, read the documentation and
+ * open the settings.
+ *
+ * @package Publishpress Series
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+define('PPSERIES_WELCOME_REDIRECT_OPTION', 'ppseries_do_welcome_redirect');
+define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_panel_dismissed');
+
+add_action('admin_init', 'ppseries_welcome_redirect');
+add_action('admin_enqueue_scripts', 'ppseries_welcome_assets');
+add_action('admin_notices', 'ppseries_welcome_panel');
+add_action('wp_ajax_ppseries_dismiss_welcome_panel', 'ppseries_dismiss_welcome_panel');
+
+/**
+ * Tell if the current screen is the Series taxonomy list screen.
+ *
+ * @return bool
+ */
+function ppseries_is_series_list_screen()
+{
+    global $pagenow;
+
+    if ('edit-tags.php' !== $pagenow) {
+        return false;
+    }
+
+    $taxonomy = isset($_GET['taxonomy']) ? sanitize_key(wp_unslash($_GET['taxonomy'])) : '';
+
+    return $taxonomy === ppseries_get_series_slug();
+}
+
+/**
+ * Send the user to the Series screen one time after activation.
+ */
+function ppseries_welcome_redirect()
+{
+    if (!get_option(PPSERIES_WELCOME_REDIRECT_OPTION)) {
+        return;
+    }
+
+    delete_option(PPSERIES_WELCOME_REDIRECT_OPTION);
+
+    // Do not interrupt a bulk or a network activation.
+    if (isset($_GET['activate-multi']) || is_network_admin() || wp_doing_ajax()) {
+        return;
+    }
+
+    if (!current_user_can('manage_publishpress_series')) {
+        return;
+    }
+
+    wp_safe_redirect(admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug()));
+    exit;
+}
+
+/**
+ * Load the styles and the script of the welcome panel.
+ */
+function ppseries_welcome_assets()
+{
+    if (!ppseries_is_series_list_screen() || !ppseries_welcome_panel_is_visible()) {
+        return;
+    }
+
+    wp_enqueue_style(
+        'ppseries-welcome',
+        SERIES_PATH_URL . 'assets/css/welcome.css',
+        [],
+        ORG_SERIES_VERSION
+    );
+
+    wp_enqueue_script(
+        'ppseries-welcome',
+        SERIES_PATH_URL . 'assets/js/welcome.js',
+        ['jquery'],
+        ORG_SERIES_VERSION,
+        true
+    );
+
+    wp_localize_script('ppseries-welcome', 'ppseriesWelcome', [
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+        'nonce'   => wp_create_nonce('ppseries_welcome_nonce'),
+    ]);
+}
+
+/**
+ * Tell if the welcome panel must be shown to the current user.
+ *
+ * @return bool
+ */
+function ppseries_welcome_panel_is_visible()
+{
+    if (!current_user_can('manage_publishpress_series')) {
+        return false;
+    }
+
+    if (get_user_meta(get_current_user_id(), PPSERIES_WELCOME_DISMISSED_META, true)) {
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Count the series terms.
+ *
+ * @return int
+ */
+function ppseries_welcome_series_count()
+{
+    $count = wp_count_terms([
+        'taxonomy'   => ppseries_get_series_slug(),
+        'hide_empty' => false,
+    ]);
+
+    return is_wp_error($count) ? 0 : (int) $count;
+}
+
+/**
+ * Show the welcome panel on the Series screen.
+ */
+function ppseries_welcome_panel()
+{
+    if (!ppseries_is_series_list_screen() || !ppseries_welcome_panel_is_visible()) {
+        return;
+    }
+
+    $has_series   = ppseries_welcome_series_count() > 0;
+    $settings_url = ppseries_series_settings_page();
+
+    $title = $has_series
+        ? esc_html__('Welcome to PublishPress Series', 'organize-series')
+        : esc_html__('Welcome! Create your first series', 'organize-series');
+
+    $description = $has_series
+        ? esc_html__('A series groups your posts together and shows your readers the reading order. Use the form on this screen to add another series, or change how your series look in the settings.', 'organize-series')
+        : esc_html__('A series groups your posts together and shows your readers the reading order. Add a name in the form on this screen to create your first series, then add posts to it.', 'organize-series');
+
+    ?>
+    <div class="ppseries-welcome-panel">
+        <button type="button" class="ppseries-welcome-dismiss" aria-label="<?php esc_attr_e('Dismiss this panel', 'organize-series'); ?>">
+            <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+        </button>
+
+        <div class="ppseries-welcome-content">
+            <h2 class="ppseries-welcome-title"><?php echo $title; ?></h2>
+            <p class="ppseries-welcome-text"><?php echo $description; ?></p>
+
+            <div class="ppseries-welcome-actions">
+                <button type="button" class="button button-primary ppseries-welcome-add">
+                    <?php
+                    echo $has_series
+                        ? esc_html__('Add New Series', 'organize-series')
+                        : esc_html__('Create Your First Series', 'organize-series');
+                    ?>
+                </button>
+
+                <a class="button" href="<?php echo esc_url($settings_url); ?>">
+                    <?php esc_html_e('Series Settings', 'organize-series'); ?>
+                </a>
+
+                <a class="button" href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">
+                    <?php esc_html_e('View Documentation', 'organize-series'); ?>
+                </a>
+
+                <?php if (!pp_series_is_pro_active()) : ?>
+                    <a class="ppseries-welcome-upgrade" href="https://publishpress.com/links/series-banner" target="_blank" rel="noopener noreferrer">
+                        <?php esc_html_e('Upgrade to Pro', 'organize-series'); ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+    <?php
+}
+
+/**
+ * Save the dismissal of the welcome panel for the current user.
+ */
+function ppseries_dismiss_welcome_panel()
+{
+    check_ajax_referer('ppseries_welcome_nonce', 'nonce');
+
+    if (!current_user_can('manage_publishpress_series')) {
+        wp_send_json_error();
+    }
+
+    update_user_meta(get_current_user_id(), PPSERIES_WELCOME_DISMISSED_META, 1);
+
+    wp_send_json_success();
+}

--- a/inc/welcome/welcome-panel.php
+++ b/inc/welcome/welcome-panel.php
@@ -2,8 +2,9 @@
 /**
  * Welcome experience for PublishPress Series.
  *
- * After activation the user goes to the Series settings page. A welcome panel
- * on that page shows the first steps: create a series, read the documentation.
+ * After activation the user goes to the Series settings page. That page shows
+ * a thank-you notice and, while the site has no series, a get-started panel
+ * with a preview of what a series looks like on the site.
  *
  * @package Publishpress Series
  */
@@ -13,10 +14,12 @@ if (!defined('ABSPATH')) {
 }
 
 define('PPSERIES_WELCOME_REDIRECT_OPTION', 'ppseries_do_welcome_redirect');
-define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_panel_dismissed');
+define('PPSERIES_WELCOME_GREETING_OPTION', 'ppseries_show_welcome_greeting');
+define('PPSERIES_WELCOME_DISMISSED_META', 'ppseries_welcome_greeting_dismissed');
 
 add_action('admin_init', 'ppseries_welcome_redirect');
 add_action('admin_enqueue_scripts', 'ppseries_welcome_assets');
+add_action('publishpress_series_settings_after_title', 'ppseries_welcome_greeting');
 add_action('publishpress_series_settings_after_title', 'ppseries_welcome_panel');
 add_action('wp_ajax_ppseries_dismiss_welcome_panel', 'ppseries_dismiss_welcome_panel');
 
@@ -57,11 +60,15 @@ function ppseries_welcome_redirect()
 }
 
 /**
- * Load the styles and the script of the welcome panel.
+ * Load the styles and the script of the welcome experience.
  */
 function ppseries_welcome_assets()
 {
-    if (!ppseries_is_series_settings_screen() || !ppseries_welcome_panel_is_visible()) {
+    if (!ppseries_is_series_settings_screen() || !current_user_can('manage_publishpress_series')) {
+        return;
+    }
+
+    if (!ppseries_welcome_greeting_is_visible() && ppseries_welcome_series_count() > 0) {
         return;
     }
 
@@ -87,21 +94,26 @@ function ppseries_welcome_assets()
 }
 
 /**
- * Tell if the welcome panel must be shown to the current user.
+ * Tell if the thank-you notice must be shown to the current user.
  *
  * @return bool
  */
-function ppseries_welcome_panel_is_visible()
+function ppseries_welcome_greeting_is_visible()
 {
     if (!current_user_can('manage_publishpress_series')) {
         return false;
     }
 
-    if (get_user_meta(get_current_user_id(), PPSERIES_WELCOME_DISMISSED_META, true)) {
+    if (!get_option(PPSERIES_WELCOME_GREETING_OPTION)) {
         return false;
     }
 
-    return true;
+    // The greeting is only for the start. It stops when the site has series.
+    if (ppseries_welcome_series_count() > 0) {
+        return false;
+    }
+
+    return !get_user_meta(get_current_user_id(), PPSERIES_WELCOME_DISMISSED_META, true);
 }
 
 /**
@@ -120,53 +132,140 @@ function ppseries_welcome_series_count()
 }
 
 /**
- * Show the welcome panel on the Series settings page.
+ * Show the thank-you notice after activation.
  */
-function ppseries_welcome_panel()
+function ppseries_welcome_greeting()
 {
-    if (!ppseries_welcome_panel_is_visible()) {
+    if (!ppseries_welcome_greeting_is_visible()) {
         return;
     }
 
-    $has_series = ppseries_welcome_series_count() > 0;
+    ?>
+    <div class="ppseries-welcome-greeting">
+        <button type="button" class="ppseries-welcome-dismiss" aria-label="<?php esc_attr_e('Dismiss this notice', 'organize-series'); ?>">
+            <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+        </button>
+        <p class="ppseries-welcome-greeting-title">
+            <span aria-hidden="true">&#128075;</span>
+            <?php esc_html_e('Thanks for installing PublishPress Series!', 'organize-series'); ?>
+        </p>
+        <p class="ppseries-welcome-greeting-text">
+            <?php esc_html_e('You are all set. Create your first series to get started.', 'organize-series'); ?>
+        </p>
+    </div>
+    <?php
+}
+
+/**
+ * Show the get-started panel while the site has no series.
+ */
+function ppseries_welcome_panel()
+{
+    if (!current_user_can('manage_publishpress_series') || ppseries_welcome_series_count() > 0) {
+        return;
+    }
+
     $series_url = admin_url('edit-tags.php?taxonomy=' . ppseries_get_series_slug());
-
-    $title = $has_series
-        ? esc_html__('Welcome to PublishPress Series', 'organize-series')
-        : esc_html__('Welcome! Create your first series', 'organize-series');
-
-    $description = $has_series
-        ? esc_html__('A series groups your posts together and shows your readers the reading order. Use the settings on this page to change how your series look, or go to the Series screen to add more series.', 'organize-series')
-        : esc_html__('A series groups your posts together and shows your readers the reading order. Start with the Series screen to create your first series, then add posts to it.', 'organize-series');
 
     ?>
     <div class="ppseries-welcome-panel">
-        <button type="button" class="ppseries-welcome-dismiss" aria-label="<?php esc_attr_e('Dismiss this panel', 'organize-series'); ?>">
-            <span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
-        </button>
+        <div class="ppseries-welcome-intro">
+            <p class="ppseries-welcome-eyebrow"><?php esc_html_e('Get started', 'organize-series'); ?></p>
+            <h2 class="ppseries-welcome-title">
+                <?php esc_html_e('Your series live here.', 'organize-series'); ?>
+            </h2>
+            <p class="ppseries-welcome-text">
+                <?php esc_html_e('Group related posts into a series. Your readers get a post list, the part number, and links to the next and previous post. No code required.', 'organize-series'); ?>
+            </p>
 
-        <div class="ppseries-welcome-content">
-            <h2 class="ppseries-welcome-title"><?php echo $title; ?></h2>
-            <p class="ppseries-welcome-text"><?php echo $description; ?></p>
+            <a class="ppseries-welcome-button" href="<?php echo esc_url($series_url); ?>">
+                <?php esc_html_e('Create your first series', 'organize-series'); ?>
+            </a>
 
-            <div class="ppseries-welcome-actions">
-                <a class="button button-primary" href="<?php echo esc_url($series_url); ?>">
-                    <?php
-                    echo $has_series
-                        ? esc_html__('Manage Your Series', 'organize-series')
-                        : esc_html__('Create Your First Series', 'organize-series');
-                    ?>
+            <ul class="ppseries-welcome-pills">
+                <li><span class="dashicons dashicons-list-view" aria-hidden="true"></span><?php esc_html_e('Automatic post list', 'organize-series'); ?></li>
+                <li><span class="dashicons dashicons-info-outline" aria-hidden="true"></span><?php esc_html_e('Part 2 of 5 details', 'organize-series'); ?></li>
+                <li><span class="dashicons dashicons-leftright" aria-hidden="true"></span><?php esc_html_e('Next and previous links', 'organize-series'); ?></li>
+            </ul>
+
+            <p class="ppseries-welcome-links">
+                <a href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">
+                    <?php esc_html_e('View documentation', 'organize-series'); ?>
                 </a>
-
-                <a class="button" href="https://publishpress.com/knowledge-base/start-series/" target="_blank" rel="noopener noreferrer">
-                    <?php esc_html_e('View Documentation', 'organize-series'); ?>
-                </a>
-
                 <?php if (!pp_series_is_pro_active()) : ?>
-                    <a class="ppseries-welcome-upgrade" href="https://publishpress.com/links/series-banner" target="_blank" rel="noopener noreferrer">
+                    <a href="https://publishpress.com/links/series-banner" target="_blank" rel="noopener noreferrer">
                         <?php esc_html_e('Upgrade to Pro', 'organize-series'); ?>
                     </a>
                 <?php endif; ?>
+            </p>
+        </div>
+
+        <div class="ppseries-welcome-preview">
+            <div class="ppseries-preview-head">
+                <span class="ppseries-preview-label"><?php esc_html_e('Preview', 'organize-series'); ?></span>
+                <div class="ppseries-preview-tabs" role="tablist">
+                    <button type="button" class="ppseries-preview-tab is-active" data-preview="list" role="tab" aria-selected="true">
+                        <?php esc_html_e('Post List', 'organize-series'); ?>
+                    </button>
+                    <button type="button" class="ppseries-preview-tab" data-preview="details" role="tab" aria-selected="false">
+                        <?php esc_html_e('Post Details', 'organize-series'); ?>
+                    </button>
+                    <button type="button" class="ppseries-preview-tab" data-preview="navigation" role="tab" aria-selected="false">
+                        <?php esc_html_e('Navigation', 'organize-series'); ?>
+                    </button>
+                </div>
+            </div>
+
+            <div class="ppseries-preview-stage">
+                <div class="ppseries-preview-pane is-active" data-preview-pane="list">
+                    <div class="ppseries-preview-card">
+                        <p class="ppseries-preview-card-title"><?php esc_html_e('The WordPress Guide', 'organize-series'); ?></p>
+                        <ol class="ppseries-preview-list">
+                            <li><?php esc_html_e('Install WordPress', 'organize-series'); ?></li>
+                            <li class="is-current"><?php esc_html_e('Choose a theme', 'organize-series'); ?></li>
+                            <li><?php esc_html_e('Add your first posts', 'organize-series'); ?></li>
+                            <li><?php esc_html_e('Set up the menus', 'organize-series'); ?></li>
+                            <li><?php esc_html_e('Go live', 'organize-series'); ?></li>
+                        </ol>
+                    </div>
+                </div>
+
+                <div class="ppseries-preview-pane" data-preview-pane="details">
+                    <div class="ppseries-preview-card">
+                        <p class="ppseries-preview-note">
+                            <?php
+                            printf(
+                                /* translators: 1: part number, 2: total posts, 3: series name */
+                                esc_html__('This entry is part %1$s of %2$s in the series %3$s', 'organize-series'),
+                                '<strong>2</strong>',
+                                '<strong>5</strong>',
+                                '<em>' . esc_html__('The WordPress Guide', 'organize-series') . '</em>'
+                            );
+                            ?>
+                        </p>
+                        <div class="ppseries-preview-lines">
+                            <span></span><span></span><span class="is-short"></span>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="ppseries-preview-pane" data-preview-pane="navigation">
+                    <div class="ppseries-preview-card">
+                        <div class="ppseries-preview-nav">
+                            <span class="ppseries-preview-nav-item">
+                                <small><?php esc_html_e('Previous in series', 'organize-series'); ?></small>
+                                <?php esc_html_e('Install WordPress', 'organize-series'); ?>
+                            </span>
+                            <span class="ppseries-preview-nav-item is-next">
+                                <small><?php esc_html_e('Next in series', 'organize-series'); ?></small>
+                                <?php esc_html_e('Add your first posts', 'organize-series'); ?>
+                            </span>
+                        </div>
+                        <div class="ppseries-preview-lines">
+                            <span></span><span class="is-short"></span>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -174,7 +273,7 @@ function ppseries_welcome_panel()
 }
 
 /**
- * Save the dismissal of the welcome panel for the current user.
+ * Save the dismissal of the thank-you notice for the current user.
  */
 function ppseries_dismiss_welcome_panel()
 {

--- a/includes-core/functions.php
+++ b/includes-core/functions.php
@@ -7,6 +7,5 @@ if (!function_exists('pp_series_core_activation')) {
         update_option('pp_series_flush_rewrite_rules', 1);
         update_option('org_series_is_initialized', 0);
         update_option('ppseries_do_welcome_redirect', 1);
-        update_option('ppseries_show_welcome_greeting', 1);
     }
 }

--- a/includes-core/functions.php
+++ b/includes-core/functions.php
@@ -6,5 +6,6 @@ if (!function_exists('pp_series_core_activation')) {
 		pp_series_upgrade_function();
         update_option('pp_series_flush_rewrite_rules', 1);
         update_option('org_series_is_initialized', 0);
+        update_option('ppseries_do_welcome_redirect', 1);
     }
 }

--- a/includes-core/functions.php
+++ b/includes-core/functions.php
@@ -7,5 +7,6 @@ if (!function_exists('pp_series_core_activation')) {
         update_option('pp_series_flush_rewrite_rules', 1);
         update_option('org_series_is_initialized', 0);
         update_option('ppseries_do_welcome_redirect', 1);
+        update_option('ppseries_show_welcome_greeting', 1);
     }
 }

--- a/src/domain/services/CoreBootstrap.php
+++ b/src/domain/services/CoreBootstrap.php
@@ -45,6 +45,9 @@ class CoreBootstrap extends AbstractBootstrap
         require_once Root::coreMeta()->getBasePath() . 'orgSeries-manage.php';
         require_once Root::coreMeta()->getBasePath() . 'inc/debug/plugin_activation_errors.php';
         require_once Root::coreMeta()->getBasePath() . 'inc/review/review-request.php';
+        if (is_admin()) {
+            require_once Root::coreMeta()->getBasePath() . 'inc/welcome/welcome-panel.php';
+        }
         require_once Root::coreMeta()->getBasePath() . 'addons/publisher/series_issue_manager.php';
         require_once Root::coreMeta()->getBasePath() . 'addons/grouping/organize-series-grouping.php';
     }


### PR DESCRIPTION
Closes #1170

## What this does

Adds a welcome experience for PublishPress Series.

- After activation, the user goes one time to `edit-tags.php?taxonomy=series`. Bulk activation, network admin, and AJAX do not trigger the redirect.
- While the site has no series, a welcome panel shows at the top of the Series screen: "Welcome! Create your first series", a short explanation that points to the Add New Series form on the same page, a **View Documentation** link, and an **Upgrade to Pro** link (free version only).
- The panel is an empty state. It goes away as soon as the site has one series. Each user can also dismiss it (user meta `ppseries_welcome_panel_dismissed`, AJAX with nonce and capability check).

## Files

- New: `inc/welcome/welcome-panel.php`, `assets/css/welcome.css`, `assets/js/welcome.js`
- Changed: `includes-core/functions.php` (activation flag), `src/domain/services/CoreBootstrap.php` (load the file in admin)

## How to test

1. On a site with no series, deactivate and activate the plugin. WordPress must open the Series screen with the panel.
2. Create a series. After the reload the panel must not show.
3. Delete all series. The panel must come back.
4. Dismiss the panel. It must stay hidden after a reload, for that user only.