### PR TITLE
Fix footer layout on publisher screen

### DIFF
--- a/addons/publisher/series_issue_manager.php
+++ b/addons/publisher/series_issue_manager.php
@@ -740,8 +740,8 @@ class PPS_Publisher_Admin
                                             <div id="publishing-action"><input type="submit" value="<?php esc_attr_e('Publish Series', 'organize-series'); ?>" class="button-primary" id="" name="publish" onclick="var im_post_IDs = new Array(); jQuery('.pp-series-publisher-wrap table.series-parts tbody tr').each( function(){im_post_IDs.push(jQuery(this).attr('id').substring(5));});jQuery('.im_publish_posts').val(im_post_IDs.join(','));" /></div>
                                             <div class="clear"></div>
                                         </div>
+                                    </div>
                                 </form>
-                            </div>
                         </div>
 
 
@@ -764,8 +764,8 @@ class PPS_Publisher_Admin
                                             <div id="publishing-action"><input type="submit" value="<?php esc_attr_e('Update Order', 'organize-series'); ?>" class="button-primary" id="" name="publish" onclick="var im_post_IDs = new Array(); jQuery('.pp-series-publisher-wrap table.series-parts tbody tr').each( function(){im_post_IDs.push(jQuery(this).attr('id').substring(5));});jQuery('.im_publish_posts').val(im_post_IDs.join(','));" /></div>
                                             <div class="clear"></div>
                                         </div>
+                                    </div>
                                 </form>
-                            </div>
 
                     </div>
 


### PR DESCRIPTION
## Summary
- Fix invalid sidebar form markup on the Publish or schedule posts screen.
- Close each postbox `.inside` container before closing its form, matching the adjacent order screen markup.
- Prevent browser markup repair from disrupting the default WordPress admin footer layout.

Fixes #1188.

## Testing
- php -l addons/publisher/series_issue_manager.php
- git diff --check
- ./vendor/bin/phpcs --report=summary (fails on existing repo baseline: 10915 errors, 339 warnings)
- PHPCS JSON check for this patch's changed lines: no findings