### PR TITLE
Fix editor preview order and tab layouts

### DIFF
--- a/addons/post-details/assets/css/series-post-details-editor.css
+++ b/addons/post-details/assets/css/series-post-details-editor.css
@@ -134,6 +134,7 @@
     vertical-align: middle;
 }
 
+#poststuff #pps_series_meta_box_editor .inside,
 #poststuff #pps_series_meta_box_editor_area .inside {
     background: #f5f6fa;
     padding: 0;

--- a/addons/post-list-box/assets/css/post-list-box-editor.css
+++ b/addons/post-list-box/assets/css/post-list-box-editor.css
@@ -272,7 +272,7 @@
     background-color: #eee;
 }
 
-.publishpress-post-list-box-editor .pps-post-list-box-editor-tabs ul li a span {
+.publishpress-post-list-box-editor .pps-post-list-box-editor-tabs ul li a > span {
     margin-right: 0.618em;
 }
 
@@ -280,6 +280,17 @@
     margin-left: 0;
     font-size: 15px;
     vertical-align: sub;
+}
+
+.publishpress-post-list-box-editor .pps-post-list-box-editor-tabs .ppseries-pro-badge {
+    line-height: 1.4;
+    margin-left: 5px;
+    margin-right: 0;
+    padding: 1px 10px;
+}
+
+.publishpress-post-list-box-editor .pps-post-list-box-editor-tabs .tooltip-text {
+    white-space: normal;
 }
 
 .publishpress-post-list-box-editor .preview-section {

--- a/addons/post-list-box/includes/class-admin-ui.php
+++ b/addons/post-list-box/includes/class-admin-ui.php
@@ -425,8 +425,8 @@ class PPS_Post_List_Box_Admin_UI {
                             <span class="<?php echo esc_attr($args['icon']); ?>"></span>
                             <span class="item"><?php echo esc_html($args['label']); ?></span>
                             <?php if ($key === 'layout' && !pp_series_is_pro_active()) : ?>
-                                <span class="ppseries-pro-lock" >
-                                    <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer" style="padding: 1px 10px;">PRO</a>
+                                <span class="ppseries-pro-lock">
+                                    <span class="ppseries-pro-badge">PRO</span>
                                     <span class="tooltip-text">
                                         <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
                                         <i></i>

--- a/addons/post-list-box/includes/class-preview.php
+++ b/addons/post-list-box/includes/class-preview.php
@@ -19,9 +19,9 @@ class PPS_Post_List_Box_Preview {
     {
         $taxonomy_slug = get_option('pp_series_taxonomy_slug', 'series');
         $query_params = [
-            'orderby' => 'date',
-            'order' => 'DESC',
-            'maximum_items' => 4,
+            'orderby' => !empty($settings['orderby']) ? $settings['orderby'] : 'series_order',
+            'order' => !empty($settings['order']) ? $settings['order'] : 'ASC',
+            'maximum_items' => !empty($settings['maximum_items']) ? (int) $settings['maximum_items'] : 4,
         ];
 
         /**
@@ -33,13 +33,18 @@ class PPS_Post_List_Box_Preview {
          */
         $query_params = apply_filters('pps_post_list_box_preview_query_params', $query_params, $settings, $series_id);
 
-        $orderby = isset($query_params['orderby']) ? $query_params['orderby'] : 'date';
-        $order = isset($query_params['order']) ? strtoupper($query_params['order']) : 'DESC';
+        $orderby = isset($query_params['orderby']) ? $query_params['orderby'] : 'series_order';
+        $order = isset($query_params['order']) ? strtoupper($query_params['order']) : 'ASC';
         $order = $order === 'ASC' ? 'ASC' : 'DESC';
         $maximum_items = isset($query_params['maximum_items']) ? (int) $query_params['maximum_items'] : 4;
+        $maximum_items = $maximum_items > 0 ? $maximum_items : 4;
+        $posts_per_page = $orderby === 'series_order' ? -1 : $maximum_items;
+        $query_orderby = $orderby === 'series_order' ? 'date' : $orderby;
+        $query_order = $orderby === 'series_order' ? 'DESC' : $order;
 
         $query_args = [
             'post_type' => 'post',
+            'post_status' => 'publish',
             'tax_query' => [
                 [
                     'taxonomy' => $taxonomy_slug,
@@ -47,9 +52,9 @@ class PPS_Post_List_Box_Preview {
                     'terms' => $series_id,
                 ],
             ],
-            'posts_per_page' => $maximum_items,
-            'orderby' => $orderby,
-            'order' => $order,
+            'posts_per_page' => $posts_per_page,
+            'orderby' => $query_orderby,
+            'order' => $query_order,
         ];
 
         /**
@@ -63,6 +68,31 @@ class PPS_Post_List_Box_Preview {
         $query_args = apply_filters('pps_post_list_box_preview_query_args', $query_args, $settings, $series_id, $query_params);
 
         $posts = get_posts($query_args);
+
+        if ($orderby === 'series_order' && !empty($posts) && function_exists('get_series_order')) {
+            $post_ids = wp_list_pluck($posts, 'ID');
+            $series_posts = get_series_order($post_ids, 0, $series_id, false, true);
+            $posts = [];
+
+            foreach ($series_posts as $series_post) {
+                if (empty($series_post['id'])) {
+                    continue;
+                }
+
+                $post = get_post((int) $series_post['id']);
+                if ($post) {
+                    $posts[] = $post;
+                }
+            }
+
+            if ($order === 'DESC') {
+                $posts = array_reverse($posts);
+            }
+
+            if ($maximum_items > 0) {
+                $posts = array_slice($posts, 0, $maximum_items);
+            }
+        }
 
         /**
          * Filter retrieved posts for post list box admin preview.

--- a/addons/post-navigation/assets/css/post-navigation-editor.css
+++ b/addons/post-navigation/assets/css/post-navigation-editor.css
@@ -8,6 +8,12 @@
     background: #fff;
 }
 
+#poststuff #pps_series_post_navigation_editor .inside {
+    background: #f5f6fa;
+    padding: 0;
+    margin-top: 0;
+}
+
 .publishpress-series-post-navigation-editor .pps-series-post-navigation-editor-tabs {
     min-width: 250px;
     margin: 0;

--- a/addons/post-navigation/includes/class-admin-ui.php
+++ b/addons/post-navigation/includes/class-admin-ui.php
@@ -140,7 +140,7 @@ class PPS_Series_Post_Navigation_Admin_UI
         $fields = PPS_Series_Post_Navigation_Fields::get_fields($post);
         $settings = PPS_Series_Post_Navigation_Utilities::get_post_navigation_settings($post->ID, $post->post_status === 'auto-draft');
 
-        echo '<div class="publishpress-series-post-navigation-editor">';
+        echo '<div class="pressshack-admin-wrapper publishpress-series-post-navigation-editor">';
 
         if (! empty($tabs)) {
             echo '<div class="pps-series-post-navigation-editor-tabs"><ul>';
@@ -157,8 +157,8 @@ class PPS_Series_Post_Navigation_Admin_UI
             echo '</ul></div>';
         }
 
-        echo '<div class="pps-series-post-navigation-editor-fields">';
-        echo '<table class="form-table pps-series-post-navigation-editor-table" role="presentation"><tbody>';
+        echo '<div class="pps-series-post-navigation-editor-fields wrapper-column">';
+        echo '<table class="form-table pps-series-post-navigation-editor-table fixed" role="presentation"><tbody>';
         foreach ($fields as $key => $field) {
             $value = isset($settings[$key]) ? $settings[$key] : '';
             $field['key'] = $key;


### PR DESCRIPTION
## Summary
- Use the Series post order for the Post List Box admin preview instead of date-desc ordering.
- Replace the nested Pro badge link inside the Post List Box tab with valid badge markup so the tab layout does not break.
- Match Post Details and Post Navigation editor spacing/wrapper behavior to the Post List Box editor.

## Testing
- php -l addons/post-list-box/includes/class-preview.php
- php -l addons/post-list-box/includes/class-admin-ui.php
- php -l addons/post-navigation/includes/class-admin-ui.php
- git diff --check
- Stubbed PHP check for ascending/descending Series-order preview output
- ./vendor/bin/phpcs addons/post-list-box/includes/class-preview.php addons/post-list-box/includes/class-admin-ui.php addons/post-navigation/includes/class-admin-ui.php (reports existing legacy standards baseline in these files)

Closes #1189
Closes #1190
Closes #1191