### PR TITLE
chore: bump minimum PHP version requirement to 7.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "minimum-stability": "stable",
   "prefer-stable": true,
   "require": {
-    "php": ">=7.2.5"
+    "php": ">=7.4.0"
   },
   "require-dev": {
     "publishpress/dev-workspace": "^1.3"

--- a/lib/composer.json
+++ b/lib/composer.json
@@ -11,7 +11,7 @@
     "classmap-authoritative": true
   },
   "require": {
-    "php": ">=7.2.5",
+    "php": ">=7.4.0",
     "publishpress/pimple-pimple": "^3.5",
     "publishpress/psr-container": "^2.0",
     "publishpress/wordpress-reviews": "^1.2",

--- a/orgSeries.php
+++ b/orgSeries.php
@@ -9,7 +9,7 @@
  * Text Domain: organize-series
  * Domain Path: /languages
  * Requires at least: 5.5
- * Requires PHP: 7.2.5
+ * Requires PHP: 7.4.0
  * License: GPLv3
  *
  * Copyright (c) 2022 PublishPress
@@ -56,7 +56,7 @@ Visit @link http://wordpress.org/extend/plugins/organize-series/changelog/ for t
 
 global $wp_version;
 
-$min_php_version = '7.2.5';
+$min_php_version = '7.4.0';
 $min_wp_version  = '5.5';
 
 $invalid_php_version = version_compare(phpversion(), $min_php_version, '<');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: publishpress, kevinB, stevejburge, andergmartins, olatechpro, riza
 Author: publishpress
 Tags: issue, series, magazine, newspaper, publication
 Requires at least: 5.5
-Requires PHP: 7.2.5
+Requires PHP: 7.4.0
 Tested up to: 7.0
 Stable tag: 3.1.3
 License: GPLv2


### PR DESCRIPTION
## Summary
- Bump minimum required PHP version from 7.2.5 to 7.4.0 to align with current WordPress and security standards.
- Updated `Requires PHP` header and `$min_php_version` check in `orgSeries.php`.
- Updated `require.php` in `composer.json` and `lib/composer.json`.
- Updated `Requires PHP` header in `readme.txt`.

## Verification
- Checked that PHP version comparison and plugin requirements match 7.4.0 consistently across all manifests.