### PR TITLE
Improve labels for Series admin controls

### DIFF
--- a/inc/settings/tab-legacy.php
+++ b/inc/settings/tab-legacy.php
@@ -152,7 +152,7 @@ function series_legacy_fieldset() {
 						</script>
 						<tr valign="top">
 							<th scope="row"><label for="series_perp_toc"><?php esc_html_e('Series Per Page:', 'organize-series'); ?></label></th>
-							<td><input type="number" name="<?php echo esc_attr($org_name); ?>[series_perp_toc]" value="<?php echo (int) ($series_perp_toc); ?>" /></td>
+							<td><input type="number" name="<?php echo esc_attr($org_name); ?>[series_perp_toc]" id="series_perp_toc" value="<?php echo (int) ($series_perp_toc); ?>" /></td>
 						</tr>
 						<tr valign="top">
 							<th scope="row"><label for="series_toc_title"><?php esc_html_e('Series Table of Contents Title:', 'organize-series'); ?></label></th>

--- a/orgSeries-admin.php
+++ b/orgSeries-admin.php
@@ -386,7 +386,7 @@ function series_edit_meta_box()
 	<div class="series-metadiv">
 		<div class="tabs-panel">
 			<p id="jaxseries">
-				<span id="ajaxseries" style="<?php echo ($metabox_show_add_new === 0) ? 'display: none;' : ''; ?>"><input type="text" name="newseries" id="newseries" size="16" autocomplete="off" /><input type="button" name="Button" class="add:serieschecklist:jaxseries button" id="seriesadd" value="<?php echo esc_attr(__('Add New', 'organize-series')); ?>" /><input type="hidden" /><input type="hidden" /></span>
+				<span id="ajaxseries" style="<?php echo ($metabox_show_add_new === 0) ? 'display: none;' : ''; ?>"><label for="newseries" class="screen-reader-text"><?php esc_html_e('New series name', 'organize-series'); ?></label><input type="text" name="newseries" id="newseries" size="16" autocomplete="off" /><input type="button" name="Button" class="add:serieschecklist:jaxseries button" id="seriesadd" value="<?php echo esc_attr(__('Add New', 'organize-series')); ?>" /><input type="hidden" /><input type="hidden" /></span>
 				<span id="series-ajax-response"></span>
 				<span id="add-series-nonce" class="hidden"><?php echo wp_create_nonce('add-series-nonce'); ?></span>
 			</p>
@@ -409,18 +409,18 @@ function series_edit_meta_box()
 				$series_part = get_post_meta($id, $part_key, true);
 				?>
 				<span id="seriespart">
-					<strong><?php esc_html_e('Series Part:', 'organize-series'); ?></strong>
+					<label for="series_part"><?php esc_html_e('Series Part:', 'organize-series'); ?></label>
 					<input class="small-text pp-series-part-input" type="number" name="series_part[<?php echo $seriesid; ?>]" id="series_part" size="5" value="<?php echo esc_attr($series_part); ?>" />
 				</span>
 			</div>
 
 			<div class="series-metabox-post-title-in-widget" style="<?php echo ($metabox_show_post_title_in_widget === 0) ? 'display: none;' : ''; ?>">
-				<strong>
-					<?php esc_html_e('Post title in widget:', 'organize-series'); ?></strong>
+				<label for="serie_post_shorttitle">
+					<?php esc_html_e('Post title in widget:', 'organize-series'); ?></label>
 				<p id="part-description" class="howto">
 					<?php esc_html_e('A short title of this post that will be used in the Series widget. Leave blank to use the full title.', 'organize-series'); ?>
 				</p>
-				<input type="text" name="serie_post_shorttitle[<?php echo isset($ser_id[0]) ? esc_attr($ser_id[0]) : 0; ?>]" id="serie_post_shorttitle" size="30" value="<?php echo esc_attr(get_post_meta($id, SPOST_SHORTTITLE_KEY, true)); ?>" />
+				<input type="text" name="serie_post_shorttitle[<?php echo isset($ser_id[0]) ? esc_attr($ser_id[0]) : 0; ?>]" id="serie_post_shorttitle" aria-describedby="part-description" size="30" value="<?php echo esc_attr(get_post_meta($id, SPOST_SHORTTITLE_KEY, true)); ?>" />
 			</div>
 
 			<input type="hidden" name="is_series_save" value="1" />

--- a/orgSeries-manage.php
+++ b/orgSeries-manage.php
@@ -278,19 +278,18 @@ function edit_series_form_fields($series, $taxonomy) {
 			<tr>
 				<th></th>
 				<td>
-				<p style="width: 50%;"><input style="margin-top: 0px;" name="delete_image" id="delete_image" type="checkbox" value="true" />  <?php _e('Delete image? (note: there will not be an image associated with this series if you select this)', 'organize-series'); ?></p>
+					<p style="width: 50%;"><label for="delete_image"><input style="margin-top: 0px;" name="delete_image" id="delete_image" type="checkbox" value="true" />  <?php esc_html_e('Delete image? (note: there will not be an image associated with this series if you select this)', 'organize-series'); ?></label></p>
 				</td>
 			</tr>
 			<?php } ?>
 			<tr valign="top">
-				<th scope="row"><?php _e('Series featured image upload:', 'organize-series') ?></th>
-				<td><label for="series_icon">
-					<input id="series_icon_loc_display" type="text" size="36" name="series_icon_loc_display" value="" disabled="disabled"/>
-					<input id="upload_image_button" type="button" value="<?php esc_attr_e('Select Image', 'organize-series'); ?>" />
-					<p><?php _e('Upload a featured image for the series.', 'organize-series'); ?></p>
-					<input id="series_icon_loc" type="hidden" name="series_icon_loc" />
-					</label>
-				</td>
+			<th scope="row"><label for="series_icon_loc_display"><?php esc_html_e('Series featured image upload:', 'organize-series'); ?></label></th>
+			<td>
+				<input id="series_icon_loc_display" type="text" size="36" name="series_icon_loc_display" value="" disabled="disabled"/>
+				<input id="upload_image_button" type="button" value="<?php esc_attr_e('Select Image', 'organize-series'); ?>" />
+				<p><?php esc_html_e('Upload a featured image for the series.', 'organize-series'); ?></p>
+				<input id="series_icon_loc" type="hidden" name="series_icon_loc" />
+			</td>
 			</tr>
 	<?php
 } 


### PR DESCRIPTION
## Summary
- add explicit labels to Series editor and term image controls
- associate the Series Per Page setting with its input
- expose the widget short-title help text through aria-describedby

## Accessibility
Addresses audit finding 2 (form input labels and associations) from the PublishPress Series Free accessibility review.

## Validation
- php -l orgSeries-admin.php
- php -l orgSeries-manage.php
- php -l inc/settings/tab-legacy.php
- git diff --check