### PR TITLE
Improve accessibility of Series tab interfaces

### DIFF
--- a/addons/post-details/assets/js/series-post-details-editor.js
+++ b/addons/post-details/assets/js/series-post-details-editor.js
@@ -7,19 +7,51 @@ jQuery(document).ready(function ($) {
 
 
         // Tab switching functionality
-        $('.pps-series-post-details-editor-tabs a').on('click', function (e) {
-            e.preventDefault();
+        var $tabs = $('.pps-series-post-details-editor-tabs [role="tab"]');
+        var $panel = $('#pps-series-post-details-editor-panel');
 
-            var tab = $(this).data('tab');
+        function activateTab($tab) {
+            var tab = $tab.data('tab');
 
-            $('.pps-series-post-details-editor-tabs a').removeClass('active');
-            $(this).addClass('active');
+            $tabs.removeClass('active').attr({
+                'aria-selected': 'false',
+                'tabindex': '-1'
+            });
+            $tab.addClass('active').attr({
+                'aria-selected': 'true',
+                'tabindex': '0'
+            });
+            $panel.attr('aria-labelledby', $tab.attr('id'));
 
             $('.pps-series-post-details-editor-table tbody tr').hide();
             $('.pps-series-post-details-editor-table tbody tr[data-tab="' + tab + '"]').show();
-            
-
             checkConditionalFields();
+        }
+
+        $tabs.off('click.ppsSeriesPostDetails keydown.ppsSeriesPostDetails');
+        $tabs.on('click.ppsSeriesPostDetails', function (e) {
+            e.preventDefault();
+            activateTab($(this));
+        });
+
+        $tabs.on('keydown.ppsSeriesPostDetails', function (e) {
+            var currentIndex = $tabs.index(this);
+            var nextIndex = currentIndex;
+
+            if (e.key === 'ArrowDown') {
+                nextIndex = (currentIndex + 1) % $tabs.length;
+            } else if (e.key === 'ArrowUp') {
+                nextIndex = (currentIndex - 1 + $tabs.length) % $tabs.length;
+            } else if (e.key === 'Home') {
+                nextIndex = 0;
+            } else if (e.key === 'End') {
+                nextIndex = $tabs.length - 1;
+            } else {
+                return;
+            }
+
+            e.preventDefault();
+            $tabs.eq(nextIndex).trigger('focus').trigger('click');
         });
 
         // Conditional field visibility handler

--- a/addons/post-details/includes/class-admin-ui.php
+++ b/addons/post-details/includes/class-admin-ui.php
@@ -107,13 +107,14 @@ class PPS_Series_Post_Details_Admin_UI
 
         echo '<div class="pressshack-admin-wrapper publishpress-series-post-details-editor">';
 
-        if (! empty($tabs)) {
-            echo '<div class="pps-series-post-details-editor-tabs"><ul>';
-            foreach ($tabs as $key => $data) {
-                $active = $key === PPS_Series_Post_Details_Fields::DEFAULT_TAB ? ' active' : '';
-                echo '<li><a href="#" data-tab="' . esc_attr($key) . '"' . $active . '>';
-                if (! empty($data['icon'])) {
-                    echo '<span class="dashicons ' . esc_attr($data['icon']) . '"></span> ';
+		if (! empty($tabs)) {
+			echo '<div class="pps-series-post-details-editor-tabs" role="tablist" aria-orientation="vertical" aria-label="' . esc_attr__('Series Post Details sections', 'organize-series') . '"><ul>';
+			foreach ($tabs as $key => $data) {
+				$active = $key === PPS_Series_Post_Details_Fields::DEFAULT_TAB ? ' active' : '';
+				$tab_id = 'pps-series-post-details-tab-' . sanitize_html_class($key);
+				echo '<li><a id="' . esc_attr($tab_id) . '" href="#" data-tab="' . esc_attr($key) . '" role="tab" aria-selected="' . ($active ? 'true' : 'false') . '" aria-controls="pps-series-post-details-editor-panel" tabindex="' . ($active ? '0' : '-1') . '"' . $active . '>';
+				if (! empty($data['icon'])) {
+					echo '<span class="dashicons ' . esc_attr($data['icon']) . '" aria-hidden="true"></span> ';
                 }
                 echo esc_html($data['label']);
                 
@@ -122,7 +123,7 @@ class PPS_Series_Post_Details_Admin_UI
             echo '</ul></div>';
         }
 
-        echo '<div class="pps-series-post-details-editor-fields wrapper-column">';
+		echo '<div id="pps-series-post-details-editor-panel" class="pps-series-post-details-editor-fields wrapper-column" role="tabpanel" aria-labelledby="pps-series-post-details-tab-' . esc_attr(sanitize_html_class(PPS_Series_Post_Details_Fields::DEFAULT_TAB)) . '" tabindex="0">';
         echo '<table class="form-table pps-series-post-details-editor-table fixed" role="presentation"><tbody>';
         foreach ($fields as $key => $field) {
             $value = isset($settings[$key]) ? $settings[$key] : '';

--- a/addons/post-list-box/assets/js/post-list-box-editor.js
+++ b/addons/post-list-box/assets/js/post-list-box-editor.js
@@ -6,13 +6,21 @@ jQuery(document).ready(function ($) {
         }
 
         // Tab switching functionality
-        $('.pps-post-list-box-editor-tabs a').on('click', function (e) {
-            e.preventDefault();
+        var $tabs = $('.pps-post-list-box-editor-tabs [role="tab"]');
+        var $panel = $('#pps-post-list-box-editor-panel');
 
-            var tab = $(this).data('tab');
+        function activateTab($tab) {
+            var tab = $tab.data('tab');
 
-            $('.pps-post-list-box-editor-tabs a').removeClass('active');
-            $(this).addClass('active');
+            $tabs.removeClass('active').attr({
+                'aria-selected': 'false',
+                'tabindex': '-1'
+            });
+            $tab.addClass('active').attr({
+                'aria-selected': 'true',
+                'tabindex': '0'
+            });
+            $panel.attr('aria-labelledby', $tab.attr('id'));
 
             $('.pps-boxes-editor-tab-content').hide();
             $('.pps-' + tab + '-tab').show();
@@ -20,10 +28,35 @@ jQuery(document).ready(function ($) {
             // Re-check dependencies after tab switch to ensure proper visibility
             setTimeout(function() {
                 if (typeof handleFieldDependencies !== 'undefined') {
-                    // Trigger dependency check
                     $('.pps-post-list-box-editor-fields input, .pps-post-list-box-editor-fields select').trigger('change');
                 }
             }, 50);
+        }
+
+        $tabs.off('click.ppsPostListBox keydown.ppsPostListBox');
+        $tabs.on('click.ppsPostListBox', function (e) {
+            e.preventDefault();
+            activateTab($(this));
+        });
+
+        $tabs.on('keydown.ppsPostListBox', function (e) {
+            var currentIndex = $tabs.index(this);
+            var nextIndex = currentIndex;
+
+            if (e.key === 'ArrowDown') {
+                nextIndex = (currentIndex + 1) % $tabs.length;
+            } else if (e.key === 'ArrowUp') {
+                nextIndex = (currentIndex - 1 + $tabs.length) % $tabs.length;
+            } else if (e.key === 'Home') {
+                nextIndex = 0;
+            } else if (e.key === 'End') {
+                nextIndex = $tabs.length - 1;
+            } else {
+                return;
+            }
+
+            e.preventDefault();
+            $tabs.eq(nextIndex).trigger('focus').trigger('click');
         });
 
         // Color picker initialization

--- a/addons/post-list-box/includes/class-admin-ui.php
+++ b/addons/post-list-box/includes/class-admin-ui.php
@@ -412,35 +412,40 @@ class PPS_Post_List_Box_Admin_UI {
         $fields = apply_filters('pps_post_list_box_editor_fields', PPS_Post_List_Box_Fields::get_fields($post), $post);
         ?>
         <div class="pressshack-admin-wrapper publishpress-post-list-box-editor">
-            <div class="pps-post-list-box-editor-tabs">
+            <div class="pps-post-list-box-editor-tabs" role="tablist" aria-orientation="vertical" aria-label="<?php esc_attr_e('Post List Box sections', 'organize-series'); ?>">
                 <ul>
                     <?php
                     foreach ($fields_tabs as $key => $args) {
                         $active_tab = ($key === PPS_Post_List_Box_Fields::default_tab()) ? ' active' : ''; ?>
                     <li>
-                        <a data-tab="<?php echo esc_attr($key); ?>"
+                        <a id="pps-post-list-box-tab-<?php echo esc_attr(sanitize_html_class($key)); ?>"
+                            data-tab="<?php echo esc_attr($key); ?>"
                             class="<?php echo esc_attr($active_tab); ?>"
                             href="#"
+                            role="tab"
+                            aria-selected="<?php echo $active_tab ? 'true' : 'false'; ?>"
+                            aria-controls="pps-post-list-box-editor-panel"
+                            tabindex="<?php echo $active_tab ? '0' : '-1'; ?>"
                             >
-                            <span class="<?php echo esc_attr($args['icon']); ?>"></span>
+                            <span class="<?php echo esc_attr($args['icon']); ?>" aria-hidden="true"></span>
                             <span class="item"><?php echo esc_html($args['label']); ?></span>
-                            <?php if ($key === 'layout' && !pp_series_is_pro_active()) : ?>
-                                <span class="ppseries-pro-lock">
-                                    <span class="ppseries-pro-badge">PRO</span>
-                                    <span class="tooltip-text">
-                                        <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
-                                        <i></i>
-                                    </span>
-                                </span>
-                            <?php endif; ?>
                         </a>
+                        <?php if ($key === 'layout' && !pp_series_is_pro_active()) : ?>
+                            <span class="ppseries-pro-lock" >
+                                <a class="ppseries-pro-badge" href="<?php echo esc_url('https://publishpress.com/links/series-banner'); ?>" target="_blank" rel="noopener noreferrer" style="padding: 1px 10px;">PRO</a>
+                                <span class="tooltip-text">
+                                    <span><?php esc_html_e('This feature is available in PublishPress Series Pro', 'organize-series'); ?></span>
+                                    <i></i>
+                                </span>
+                            </span>
+                        <?php endif; ?>
                     </li>
                     <?php
                     } ?>
                 </ul>
             </div>
 
-            <div class="pps-post-list-box-editor-fields wrapper-column">
+            <div id="pps-post-list-box-editor-panel" class="pps-post-list-box-editor-fields wrapper-column" role="tabpanel" aria-labelledby="pps-post-list-box-tab-<?php echo esc_attr(sanitize_html_class(PPS_Post_List_Box_Fields::default_tab())); ?>" tabindex="0">
                 <table class="form-table pps-post-list-boxes-editor-table fixed" role="presentation">
                     <tbody>
                         <?php

--- a/addons/post-navigation/assets/js/series-post-navigation-editor.js
+++ b/addons/post-navigation/assets/js/series-post-navigation-editor.js
@@ -31,29 +31,60 @@
         }
 
         // Tab switching
-        $('.pps-series-post-navigation-editor-tabs a').on('click', function(e) {
-            e.preventDefault();
-            var tab = $(this).data('tab');
-            
-            // Update active tab
-            $('.pps-series-post-navigation-editor-tabs a').removeClass('active');
-            $(this).addClass('active');
-            
-            // Show/hide fields
+        var $tabs = $('.pps-series-post-navigation-editor-tabs [role="tab"]');
+        var $panel = $('#pps-series-post-navigation-editor-panel');
+
+        function activateTab($tab) {
+            var tab = $tab.data('tab');
+
+            $tabs.removeClass('active').attr({
+                'aria-selected': 'false',
+                'tabindex': '-1'
+            });
+            $tab.addClass('active').attr({
+                'aria-selected': 'true',
+                'tabindex': '0'
+            });
+            $panel.attr('aria-labelledby', $tab.attr('id'));
+
             $('.pps-series-post-navigation-editor-table tr').each(function() {
-                var fieldTab = $(this).data('tab');
-                if (fieldTab === tab) {
+                if ($(this).data('tab') === tab) {
                     $(this).show();
                 } else {
                     $(this).hide();
                 }
             });
 
-            // Re-apply all field visibility rules when returning to tab
             toggleLabelFields();
             toggleFeaturedImageFields();
             toggleArrowFields();
             toggleSeriesTitleFields();
+        }
+
+        $tabs.off('click.ppsSeriesPostNavigation keydown.ppsSeriesPostNavigation');
+        $tabs.on('click.ppsSeriesPostNavigation', function(e) {
+            e.preventDefault();
+            activateTab($(this));
+        });
+
+        $tabs.on('keydown.ppsSeriesPostNavigation', function(e) {
+            var currentIndex = $tabs.index(this);
+            var nextIndex = currentIndex;
+
+            if (e.key === 'ArrowDown') {
+                nextIndex = (currentIndex + 1) % $tabs.length;
+            } else if (e.key === 'ArrowUp') {
+                nextIndex = (currentIndex - 1 + $tabs.length) % $tabs.length;
+            } else if (e.key === 'Home') {
+                nextIndex = 0;
+            } else if (e.key === 'End') {
+                nextIndex = $tabs.length - 1;
+            } else {
+                return;
+            }
+
+            e.preventDefault();
+            $tabs.eq(nextIndex).trigger('focus').trigger('click');
         });
 
         // Toggle label field visibility based on dropdown selections

--- a/addons/post-navigation/includes/class-admin-ui.php
+++ b/addons/post-navigation/includes/class-admin-ui.php
@@ -142,13 +142,14 @@ class PPS_Series_Post_Navigation_Admin_UI
 
         echo '<div class="pressshack-admin-wrapper publishpress-series-post-navigation-editor">';
 
-        if (! empty($tabs)) {
-            echo '<div class="pps-series-post-navigation-editor-tabs"><ul>';
-            foreach ($tabs as $key => $data) {
-                $active = $key === PPS_Series_Post_Navigation_Fields::DEFAULT_TAB ? ' active' : '';
-                echo '<li><a href="#" data-tab="' . esc_attr($key) . '"' . $active . '>';
-                if (! empty($data['icon'])) {
-                    echo '<span class="dashicons ' . esc_attr($data['icon']) . '"></span> ';
+		if (! empty($tabs)) {
+			echo '<div class="pps-series-post-navigation-editor-tabs" role="tablist" aria-orientation="vertical" aria-label="' . esc_attr__('Series Post Navigation sections', 'organize-series') . '"><ul>';
+			foreach ($tabs as $key => $data) {
+				$active = $key === PPS_Series_Post_Navigation_Fields::DEFAULT_TAB ? ' active' : '';
+				$tab_id = 'pps-series-post-navigation-tab-' . sanitize_html_class($key);
+				echo '<li><a id="' . esc_attr($tab_id) . '" href="#" data-tab="' . esc_attr($key) . '" role="tab" aria-selected="' . ($active ? 'true' : 'false') . '" aria-controls="pps-series-post-navigation-editor-panel" tabindex="' . ($active ? '0' : '-1') . '"' . $active . '>';
+				if (! empty($data['icon'])) {
+					echo '<span class="dashicons ' . esc_attr($data['icon']) . '" aria-hidden="true"></span> ';
                 }
                 echo esc_html($data['label']);
                 
@@ -157,7 +158,7 @@ class PPS_Series_Post_Navigation_Admin_UI
             echo '</ul></div>';
         }
 
-        echo '<div class="pps-series-post-navigation-editor-fields wrapper-column">';
+		echo '<div id="pps-series-post-navigation-editor-panel" class="pps-series-post-navigation-editor-fields wrapper-column" role="tabpanel" aria-labelledby="pps-series-post-navigation-tab-' . esc_attr(sanitize_html_class(PPS_Series_Post_Navigation_Fields::DEFAULT_TAB)) . '" tabindex="0">';
         echo '<table class="form-table pps-series-post-navigation-editor-table fixed" role="presentation"><tbody>';
         foreach ($fields as $key => $field) {
             $value = isset($settings[$key]) ? $settings[$key] : '';

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -266,7 +266,8 @@
         'aria-selected': 'false',
         'tabindex': '-1'
       });
-      $('.ppseries-settings-tab-content').addClass('ppseries-hide-content').attr('hidden', true);
+      $('.ppseries-settings-tab-content').addClass('ppseries-hide-content');
+      $('.ppseries-settings-tab-content[role="tabpanel"]').attr('hidden', true);
       $('input[name="update_orgseries"]').show();
 
       if( current_content === '#series_license_settings'){

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -257,19 +257,27 @@
     // -------------------------------------------------------------
     //   Settings tab click
     // -------------------------------------------------------------
-    $(document).on('click', '.ppseries-settings-tab .nav-tab', function (e) {
-      e.preventDefault();
-      var current_content = $(this).attr('href');
-      $('.ppseries-settings-tab .nav-tab').removeClass('nav-tab-active');
-      $('.ppseries-settings-tab-content').addClass('ppseries-hide-content');
+    function activateSettingsTab($tab) {
+      var current_content = $tab.attr('href');
+      var $tabs = $('.ppseries-settings-tab [role="tab"]');
+      var $content = $(current_content + '-series-content');
+
+      $tabs.removeClass('nav-tab-active').attr({
+        'aria-selected': 'false',
+        'tabindex': '-1'
+      });
+      $('.ppseries-settings-tab-content').addClass('ppseries-hide-content').attr('hidden', true);
       $('input[name="update_orgseries"]').show();
 
       if( current_content === '#series_license_settings'){
         $('input[name="update_orgseries"]').hide();
       }
 
-      $(this).addClass('nav-tab-active');
-      $(current_content+'-series-content').removeClass('ppseries-hide-content');
+      $tab.addClass('nav-tab-active').attr({
+        'aria-selected': 'true',
+        'tabindex': '0'
+      });
+      $content.removeClass('ppseries-hide-content').removeAttr('hidden');
 
       if ($(current_content + '-series-tab').hasClass('series-tab-content'))
       {
@@ -279,6 +287,32 @@
       if (typeof(localStorage) != 'undefined' && localStorage != null) {
           localStorage.setItem("pp_series_activetab", current_content);
       }
+    }
+
+    $(document).on('click', '.ppseries-settings-tab [role="tab"]', function (e) {
+      e.preventDefault();
+      activateSettingsTab($(this));
+    });
+
+    $(document).on('keydown', '.ppseries-settings-tab [role="tab"]', function (e) {
+      var $tabs = $('.ppseries-settings-tab [role="tab"]');
+      var current_index = $tabs.index(this);
+      var next_index = current_index;
+
+      if (e.key === 'ArrowRight') {
+        next_index = (current_index + 1) % $tabs.length;
+      } else if (e.key === 'ArrowLeft') {
+        next_index = (current_index - 1 + $tabs.length) % $tabs.length;
+      } else if (e.key === 'Home') {
+        next_index = 0;
+      } else if (e.key === 'End') {
+        next_index = $tabs.length - 1;
+      } else {
+        return;
+      }
+
+      e.preventDefault();
+      $tabs.eq(next_index).trigger('focus').trigger('click');
 
     });
 

--- a/inc/settings/settings-page.php
+++ b/inc/settings/settings-page.php
@@ -22,9 +22,10 @@ function orgseries_option_page() {
 	update_option('orgseries_update_message','');
 	?>
 
-  <h2 class="nav-tab-wrapper ppseries-settings-tab">
+  <nav class="nav-tab-wrapper ppseries-settings-tab" role="tablist" aria-label="<?php esc_attr_e('Series settings', 'organize-series'); ?>">
   <?php
     $settings_tabs = ppseries_admin_settings_tabs();
+    $first_tab = true;
     foreach($settings_tabs as $settings_tab_key => $settings_tab_label){
       /*if(apply_filters('ppseries_settings_'.$settings_tab_key.'_tabbed', false)){
         $tabbled_class = 'series-tab-content';
@@ -33,10 +34,11 @@ function orgseries_option_page() {
       }*/
       $tabbled_class = 'series-tab-content';
       // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-      echo '<a id="'. esc_attr($settings_tab_key) .'-series-tab" class="nav-tab '. esc_attr($tabbled_class) .'" href="#'. $settings_tab_key .'">'.$settings_tab_label.'</a>';
+      echo '<a id="'. esc_attr($settings_tab_key) .'-series-tab" class="nav-tab '. esc_attr($tabbled_class) .'" href="#'. esc_attr($settings_tab_key) .'" role="tab" aria-selected="'. ($first_tab ? 'true' : 'false') .'" aria-controls="'. esc_attr($settings_tab_key) .'-series-content" tabindex="'. ($first_tab ? '0' : '-1') .'">'. esc_html($settings_tab_label) .'</a>';
+      $first_tab = false;
     }
   ?>
-  </h2>
+  </nav>
 
 
 	<div id="poststuff" class="metabox-holder has-right-sidebar ppseries-settings-layout">

--- a/orgSeries-utility.php
+++ b/orgSeries-utility.php
@@ -335,7 +335,7 @@ function ppseries_do_settings_sections( $page ) {
 
 	foreach ( (array) $wp_settings_sections[ $page ] as $section ) {
 
-		echo '<div id="'. esc_attr($section['id']).'-series-content" class="ppseries-settings-tab-content ppseries-hide-content">';
+		echo '<div id="'. esc_attr($section['id']).'-series-content" class="ppseries-settings-tab-content ppseries-hide-content" role="tabpanel" aria-labelledby="'. esc_attr($section['id']) .'-series-tab" tabindex="0" hidden>';
 		/*if ( $section['title'] ) {
 			echo "<h2>{$section['title']}</h2>\n";
 		}*/


### PR DESCRIPTION
## Summary
- expose Series settings and layout editors as semantic tab interfaces
- add selected state, controlled panels, and visible tab sequencing
- support arrow, Home, and End keyboard navigation
- avoid nesting the Pro link inside the Post List Box tab link

## Accessibility
Addresses audit finding 4 from the PublishPress Series Free accessibility review.

## Validation
- node --check on all four changed JavaScript files
- php -l on all changed PHP files
- git diff --check