### PR TITLE
Make Series help tooltips keyboard accessible

### DIFF
--- a/assets/js/tooltip.min.js
+++ b/assets/js/tooltip.min.js
@@ -1,1 +1,91 @@
-(function(global){const PP_TooltipsLibrary={init(){this.applyTooltips(document);this.bindGlobalClick()},applyTooltips(context=document){const tooltips=context.querySelectorAll('[data-toggle="tooltip"].pp-tooltips-library');tooltips.forEach(tooltip=>{if(tooltip.dataset.tooltipProcessed==="true")return;tooltip.dataset.tooltipProcessed="true";const tooltipBox=tooltip.querySelector(".tooltip-text");if(!tooltipBox)return;if(!tooltipBox.querySelector("i")){const arrow=document.createElement("i");tooltipBox.appendChild(arrow)}if(tooltip.classList.contains("click")){tooltip.addEventListener("click",e=>{e.preventDefault();e.stopPropagation();tooltip.classList.toggle("is-active")})}})},bindGlobalClick(){document.addEventListener("click",function(event){const tooltip=event.target.closest('[data-toggle="tooltip"].pp-tooltips-library.click');if(tooltip){event.preventDefault();event.stopPropagation();tooltip.classList.toggle("is-active")}})},refresh(context=document){this.applyTooltips(context)}};document.addEventListener("DOMContentLoaded",()=>PP_TooltipsLibrary.init());global.PP_TooltipsLibrary=PP_TooltipsLibrary})(window);
+(function (global) {
+    const PP_TooltipsLibrary = {
+        counter: 0,
+
+        init() {
+            this.applyTooltips(document);
+            this.bindGlobalClick();
+        },
+
+        nextTooltipId() {
+            this.counter += 1;
+            return 'ppseries-tooltip-' + this.counter;
+        },
+
+        toggle(tooltip) {
+            const isActive = tooltip.classList.toggle('is-active');
+            tooltip.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+        },
+
+        applyTooltips(context = document) {
+            const tooltips = context.querySelectorAll('[data-toggle="tooltip"].pp-tooltips-library');
+
+            tooltips.forEach(tooltip => {
+                if (tooltip.dataset.tooltipProcessed === 'true') {
+                    return;
+                }
+
+                tooltip.dataset.tooltipProcessed = 'true';
+                const tooltipBox = tooltip.querySelector('.tooltip-text');
+
+                if (!tooltipBox) {
+                    return;
+                }
+
+                tooltip.tabIndex = 0;
+
+                if (!tooltipBox.id) {
+                    tooltipBox.id = this.nextTooltipId();
+                }
+
+                tooltip.setAttribute('aria-describedby', tooltipBox.id);
+
+                if (tooltip.classList.contains('click')) {
+                    tooltip.setAttribute('role', 'button');
+                    tooltip.setAttribute('aria-expanded', 'false');
+                    tooltip.addEventListener('click', event => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        this.toggle(tooltip);
+                    });
+                    tooltip.addEventListener('keydown', event => {
+                        if (event.key !== 'Enter' && event.key !== ' ') {
+                            return;
+                        }
+
+                        event.preventDefault();
+                        event.stopPropagation();
+                        this.toggle(tooltip);
+                    });
+                }
+
+                if (!tooltipBox.querySelector('i')) {
+                    const arrow = document.createElement('i');
+                    arrow.setAttribute('aria-hidden', 'true');
+                    tooltipBox.appendChild(arrow);
+                }
+            });
+        },
+
+        bindGlobalClick() {
+            document.addEventListener('click', event => {
+                const tooltip = event.target.closest('[data-toggle="tooltip"].pp-tooltips-library.click');
+
+                if (!tooltip) {
+                    return;
+                }
+
+                event.preventDefault();
+                event.stopPropagation();
+                this.toggle(tooltip);
+            });
+        },
+
+        refresh(context = document) {
+            this.applyTooltips(context);
+        }
+    };
+
+    document.addEventListener('DOMContentLoaded', () => PP_TooltipsLibrary.init());
+    global.PP_TooltipsLibrary = PP_TooltipsLibrary;
+}(window));

--- a/orgSeries-admin.css
+++ b/orgSeries-admin.css
@@ -369,7 +369,8 @@ input #seriesadd {
     border-top: 5px solid #333;
 }
 
-.ppseries-pro-lock:hover .tooltip-text {
+.ppseries-pro-lock:hover .tooltip-text,
+.ppseries-pro-lock:focus-within .tooltip-text {
     visibility: visible;
     opacity: 1;
 }


### PR DESCRIPTION
## Summary
- make Series help tooltips keyboard reachable
- expose tooltip content through aria-describedby
- support keyboard activation for click-to-open tooltips and focus visibility for PRO locks

## Accessibility finding
Addresses finding 5 from the Series Free accessibility audit: tooltip help was hover/click-only and unavailable or unclear for keyboard and assistive-technology users.

## Validation
- node --check assets/js/tooltip.min.js
- git diff --check