### PR TITLE
Improve accessibility of Series dynamic updates

### DIFF
--- a/addons/post-navigation/assets/js/series-post-navigation-editor.js
+++ b/addons/post-navigation/assets/js/series-post-navigation-editor.js
@@ -253,7 +253,7 @@
                     ? attachment.sizes.thumbnail.url 
                     : attachment.url;
                     
-                $preview.html('<img src="' + imageUrl + '" style="max-width: 150px; max-height: 150px; display: block; margin-bottom: 10px;" />');
+                $preview.html('<img src="' + imageUrl + '" alt="" style="max-width: 150px; max-height: 150px; display: block; margin-bottom: 10px;" />');
                 
                 // Update button text
                 button.text('Change Image');

--- a/addons/post-navigation/includes/class-admin-ui.php
+++ b/addons/post-navigation/includes/class-admin-ui.php
@@ -400,9 +400,15 @@ class PPS_Series_Post_Navigation_Admin_UI
                         
                         echo '<div class="pps-media-preview" style="margin-bottom: 10px;">';
                         if ($has_image) {
+                            $image_alt = get_post_meta($attachment_id, '_wp_attachment_image_alt', true);
+                            if ('' === $image_alt) {
+                                $image_alt = get_the_title($attachment_id);
+                            }
+
                             printf(
-                                '<img src="%s" style="max-width: 150px; max-height: 150px; display: block; margin-bottom: 10px;" />',
-                                esc_url($image_url)
+                                '<img src="%s" alt="%s" style="max-width: 150px; max-height: 150px; display: block; margin-bottom: 10px;" />',
+                                esc_url($image_url),
+                                esc_attr($image_alt)
                             );
                         }
                         echo '</div>';

--- a/js/orgseries_scripts.js
+++ b/js/orgseries_scripts.js
@@ -38,7 +38,7 @@
 			$('#series_icon_loc').val(imgurl);
 			$('#series_icon_loc_display').val(imgurl);
 			tb_remove();
-			var view_image_url = "Selected Image:<br /> <img src=\"" + imgurl + "\" width=\"100px\" />";
+			var view_image_url = "Selected Image:<br /> <img src=\"" + imgurl + "\" width=\"100px\" alt=\"\" />";
 			$('#selected-icon').html(view_image_url)
 	}
 
@@ -90,7 +90,7 @@ $(document).on('click', '#upload_image_button', function (e) {
 				 var attachment = custom_feedback_image_frame.state().get('selection').first().toJSON();
 					 $(upload_input).val(attachment.url);
 					 $(upload_display).val(attachment.url);
-		 			var view_image_url = "Selected Image:<br /> <img src=\"" + attachment.url + "\" width=\"100px\" />";
+					var view_image_url = "Selected Image:<br /> <img src=\"" + attachment.url + "\" width=\"100px\" alt=\"\" />";
 		 			$('#selected-icon').html(view_image_url)
 				 }
 

--- a/js/series.js
+++ b/js/series.js
@@ -44,8 +44,9 @@ jQuery(document).ready( function($) {
 				$('ul#serieschecklist li:first').after(resp.html);
 				$('#series-'+resp.id).animate({backgroundColor: "transparent"}, 3000);
 				$('#add-series-nonce').text(resp.new_nonce);
+				$('#series-ajax-response').text(resp.message || '');
 			} else {
-				$('#series-ajax-response').html(resp.error);
+				$('#series-ajax-response').text(resp.error);
 			}
 		});
 	});

--- a/orgSeries-admin.php
+++ b/orgSeries-admin.php
@@ -169,7 +169,7 @@ function orgSeries_admin_footer()
 
 				<div class="pp-pressshack-logo">
 					<a href="https://publishpress.com" target="_blank" rel="noopener noreferrer">
-						<img src="<?php echo esc_url(SERIES_PATH_URL . 'assets/images/publishpress-logo.png'); ?>" />
+						<img src="<?php echo esc_url(SERIES_PATH_URL . 'assets/images/publishpress-logo.png'); ?>" alt="<?php esc_attr_e('PublishPress', 'organize-series'); ?>" />
 					</a>
 				</div>
 			</footer>
@@ -220,6 +220,7 @@ function admin_ajax_series()
 			'id' => $series_id,
 			'html' => "<li id='series-$series_id' class='series-added-indicator'><label for='in-series-$series_id' class='selectit'><input value='$series_id' type='radio' name='post_series' id='in-series-$series_id' checked /><input type='hidden' name='is_series_save' value='1' /> <span class='li-series-name'>$series_name</span></label><span id='new_series_id' class='hidden'>$series_id</span></li>",
 			'new_nonce' => $new_nonce,
+			'message' => __('Series added.', 'organize-series'),
 			'error' => false
 		);
 	}
@@ -387,10 +388,9 @@ function series_edit_meta_box()
 		<div class="tabs-panel">
 			<p id="jaxseries">
 				<span id="ajaxseries" style="<?php echo ($metabox_show_add_new === 0) ? 'display: none;' : ''; ?>"><label for="newseries" class="screen-reader-text"><?php esc_html_e('New series name', 'organize-series'); ?></label><input type="text" name="newseries" id="newseries" size="16" autocomplete="off" /><input type="button" name="Button" class="add:serieschecklist:jaxseries button" id="seriesadd" value="<?php echo esc_attr(__('Add New', 'organize-series')); ?>" /><input type="hidden" /><input type="hidden" /></span>
-				<span id="series-ajax-response"></span>
+				<span id="series-ajax-response" role="status" aria-live="polite" aria-atomic="true"></span>
 				<span id="add-series-nonce" class="hidden"><?php echo wp_create_nonce('add-series-nonce'); ?></span>
 			</p>
-			<span id="series-ajax-response"></span>
 
 			<?php if (is_array($series_list) && count($series_list) > 1) : ?>
 				<div class="editor-series-search">

--- a/orgSeries-manage.php
+++ b/orgSeries-manage.php
@@ -271,7 +271,7 @@ function edit_series_form_fields($series, $taxonomy) {
 							echo '<p>'. esc_html__('No featured image currently', 'organize-series') .'</p>';
 						}
 					 ?>
-					<div id="selected-icon"></div>
+					<div id="selected-icon" role="status" aria-live="polite" aria-atomic="true"></div>
 				</td>
 			</tr>
 			<?php if ( $series_icon != '' ) { ?>


### PR DESCRIPTION
## Summary
- announce successful and failed Series additions through a live status region
- remove the duplicate AJAX status ID
- add accessible alternatives to Series image previews and the admin logo

## Accessibility finding
Addresses finding 6 from the Series Free accessibility audit: dynamic updates were not announced reliably and several generated image elements had no alt attribute.

## Validation
- php -l on changed PHP files
- node --check on changed JavaScript files
- git diff --check