### PR TITLE
Improve Series text contrast

### DIFF
--- a/addons/post-details/assets/css/series-post-details-editor.css
+++ b/addons/post-details/assets/css/series-post-details-editor.css
@@ -169,7 +169,7 @@
 }
 
 .pps-series-post-details-editor-table .field-description {
-    color: gray;
+    color: #50575e;
 }
 
 .pps-series-post-details-editor-table .series-meta-boxes-field-icon {

--- a/addons/post-list-box/assets/css/post-list-box-editor.css
+++ b/addons/post-list-box/assets/css/post-list-box-editor.css
@@ -171,7 +171,7 @@
 }
 
 .pps-post-list-boxes-editor-table .field-description {
-    color: gray;
+    color: #50575e;
 }
 
 .pps-post-list-boxes-editor-table .post-list-boxes-field-icon {

--- a/addons/post-navigation/assets/css/post-navigation-editor.css
+++ b/addons/post-navigation/assets/css/post-navigation-editor.css
@@ -89,7 +89,7 @@
 }
 
 .pps-series-post-navigation-editor-table .field-description {
-    color: gray;
+    color: #50575e;
 }
 
 .pps-category-separator {

--- a/addons/post-navigation/classes/PostNavigationRenderer.php
+++ b/addons/post-navigation/classes/PostNavigationRenderer.php
@@ -260,7 +260,7 @@ class PostNavigationRenderer
 
         // Check if we should hide when single post
         if (!empty($settings['hide_when_single_post']) && $total_posts <= 1) {
-            return '<p style="color: #999; font-style: italic;">' . esc_html__('Navigation hidden (series has only one post)', 'organize-series') . '</p>';
+            return '<p style="color: #50575e; font-style: italic;">' . esc_html__('Navigation hidden (series has only one post)', 'organize-series') . '</p>';
         }
 
         $content_parts = [];

--- a/assets/css/pressshack-admin.css
+++ b/assets/css/pressshack-admin.css
@@ -98,7 +98,7 @@
 }
 
 .pressshack-admin-wrapper > footer * {
-    color: #777;
+    color: #50575e;
 }
 
 .pressshack-admin-wrapper > footer > nav ul {

--- a/orgSeries-admin.css
+++ b/orgSeries-admin.css
@@ -305,7 +305,7 @@ input #seriesadd {
 
 .ppseries-warning {
     border: 1px solid rgb(230, 219, 84);
-    color: #8a8a8a;
+    color: #50575e;
     font-size: 13px;
     padding: 12px 25px;
     background-color: rgb(254, 255, 224);


### PR DESCRIPTION
## Summary
- improve contrast for Series editor field descriptions
- improve contrast for admin footer text, warnings, and hidden-navigation notices

## Accessibility finding
Addresses finding 7 from the Series Free accessibility audit: several secondary-text and notice colors did not provide sufficient contrast against their backgrounds.

## Validation
- git diff --check
- verified the audited low-contrast color values are no longer used in the affected selectors