### PR TITLE
Improve remaining Series admin semantics

### DIFF
--- a/inc/pue-client.php
+++ b/inc/pue-client.php
@@ -35,7 +35,13 @@ if ( !class_exists('PluginUpdateEngineChecker') ):
 			?>
             <div class="notice error">
                 <p>
-                    Publishpress Series Add-on licensing has changed.  This notice only appears by sites affected by this change.  You can read more about the change <a href="http://docs.organizeseries.com/article/77-licensing-changes-in-organize-series">here.</a>
+                    <?php
+                    printf(
+                        /* translators: %s is a link to the licensing change documentation. */
+                        esc_html__('PublishPress Series Add-on licensing has changed. This notice only appears on sites affected by this change. You can %s.', 'organize-series'),
+                        '<a href="' . esc_url('http://docs.organizeseries.com/article/77-licensing-changes-in-organize-series') . '">' . esc_html__('read more about this licensing change', 'organize-series') . '</a>'
+                    );
+                    ?>
                 </p>
                 <p>
                     The new fields for your license keys are found in the sidebar on this page, labelled "Extension Licenses".  This notice will disappear once all of your Publishpress Series add-ons have been updated.

--- a/inc/settings/settings-page.php
+++ b/inc/settings/settings-page.php
@@ -304,10 +304,11 @@ function orgseries_option_page() {
 					<input type="submit" class="button-primary" name="update_orgseries" value="<?php esc_attr_e('Update Options', 'organize-series'); ?>" />
 				</span>
 				</form>
-				<div id="TBcontent" class="reset_dialog" style="display:none;">
-					<p> <?php esc_html_e('Clicking Yes will reset the options to the defaults and you will lose all customizations. Or you can click cancel and return.', 'organize-series'); ?></p>
-					<input type="submit" id="TBcancel" class="button" value="<?php esc_attr_e('No', 'organize-series'); ?>" />
-					<input type="submit" id="TBsubmit" class="alignright button-primary" value="<?php esc_attr_e('Yes', 'organize-series'); ?>" />
+				<div id="TBcontent" class="reset_dialog" role="dialog" aria-modal="true" aria-labelledby="TBtitle" aria-describedby="TBdescription" tabindex="-1" style="display:none;">
+					<h2 id="TBtitle" class="screen-reader-text"><?php esc_html_e('Reset Series settings', 'organize-series'); ?></h2>
+					<p id="TBdescription"><?php esc_html_e('Clicking Yes will reset the options to the defaults and you will lose all customizations. Or you can click cancel and return.', 'organize-series'); ?></p>
+					<button type="button" id="TBcancel" class="button"><?php esc_html_e('No', 'organize-series'); ?></button>
+					<button type="button" id="TBsubmit" class="alignright button-primary"><?php esc_html_e('Yes', 'organize-series'); ?></button>
 				</div>
 		</div>
 		</div>

--- a/inc/settings/settings-page.php
+++ b/inc/settings/settings-page.php
@@ -304,11 +304,13 @@ function orgseries_option_page() {
 					<input type="submit" class="button-primary" name="update_orgseries" value="<?php esc_attr_e('Update Options', 'organize-series'); ?>" />
 				</span>
 				</form>
-				<div id="TBcontent" class="reset_dialog" role="dialog" aria-modal="true" aria-labelledby="TBtitle" aria-describedby="TBdescription" tabindex="-1" style="display:none;">
-					<h2 id="TBtitle" class="screen-reader-text"><?php esc_html_e('Reset Series settings', 'organize-series'); ?></h2>
-					<p id="TBdescription"><?php esc_html_e('Clicking Yes will reset the options to the defaults and you will lose all customizations. Or you can click cancel and return.', 'organize-series'); ?></p>
-					<button type="button" id="TBcancel" class="button"><?php esc_html_e('No', 'organize-series'); ?></button>
-					<button type="button" id="TBsubmit" class="alignright button-primary"><?php esc_html_e('Yes', 'organize-series'); ?></button>
+				<div id="TBcontent" style="display:none;">
+					<div class="reset_dialog" role="dialog" aria-modal="true" aria-labelledby="TBtitle" aria-describedby="TBdescription" tabindex="-1">
+						<h2 id="TBtitle" class="screen-reader-text"><?php esc_html_e('Reset Series settings', 'organize-series'); ?></h2>
+						<p id="TBdescription"><?php esc_html_e('Clicking Yes will reset the options to the defaults and you will lose all customizations. Or you can click cancel and return.', 'organize-series'); ?></p>
+						<button type="button" id="TBcancel" class="button"><?php esc_html_e('No', 'organize-series'); ?></button>
+						<button type="button" id="TBsubmit" class="alignright button-primary"><?php esc_html_e('Yes', 'organize-series'); ?></button>
+					</div>
 				</div>
 		</div>
 		</div>

--- a/inc/settings/tab-advanced.php
+++ b/inc/settings/tab-advanced.php
@@ -43,45 +43,38 @@ function series_uninstall_core_fieldset() {
         	</tr>
 
         	<tr valign="top">
-            	<th scope="row"><label for="kill_on_delete">
+            <th scope="row">
                 	    <?php esc_html_e('Series Upgrade', 'organize-series'); ?>
-                	</label>
             	</th>
 
             	<td>
 					<a class="button" href="<?php echo esc_url(admin_url('admin.php?page=orgseries_options_page&series_action=multiple-series-support&nonce='. wp_create_nonce('multiple-series-support-upgrade'))); ?>"><?php esc_html_e('Run Upgrade Task', 'organize-series'); ?></a>
                     <div>
-						<label>
-							<span class="description">
+						<span class="description">
 								<?php esc_html_e('In version 2.11.4, PublishPress Series made changes to how series are stored. You can run the upgrade task here if you\'re having issues with series parts.', 'organize-series'); ?>
-							</span>
-						</label>
+						</span>
                     </div>
                 </td>
         	</tr>
 
 			<tr valign="top">
-            	<th scope="row"><label>
+            <th scope="row">
                 	    <?php esc_html_e('Sync Series Order to Menu Order', 'organize-series'); ?>
-                	</label>
             	</th>
 
             	<td>
 					<a class="button" href="<?php echo esc_url(admin_url('admin.php?page=orgseries_options_page&series_action=sync-menu-order&nonce='. wp_create_nonce('sync-menu-order-action'))); ?>"><?php esc_html_e('Sync to Menu Order', 'organize-series'); ?></a>
                     <div>
-						<label>
-							<span class="description">
+						<span class="description">
 								<?php esc_html_e('This will sync all series part numbers to WordPress menu_order field. Useful for themes/page builders that can only sort by menu order (Page Attributes: Order). This allows you to use native WordPress ordering instead of custom fields.', 'organize-series'); ?>
-							</span>
-						</label>
+						</span>
                     </div>
                 </td>
         	</tr>
 
 			<tr valign="top">
-            	<th scope="row"><label>
+            <th scope="row">
                 	    <?php esc_html_e('Reset settings', 'organize-series'); ?>
-                	</label>
             	</th>
             	<td><input type="submit" class="button" name="option_reset" value="<?php esc_attr_e('Reset options to default', 'organize-series'); ?>" /></td>
         	</tr>

--- a/inc/settings/tab-legacy.php
+++ b/inc/settings/tab-legacy.php
@@ -79,8 +79,8 @@ function series_legacy_fieldset() {
 										<?php
 										echo sprintf(
 											// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-											__('Choosing a layout different to "Default" will override the taxonomy template from your theme. <a href="%s" target="_blank">Click here for details on how to customize these designs</a>.', 'organize-series'),
-											'https://publishpress.com/knowledge-base/series-archive-templates/'
+											__('Choosing a layout different to "Default" will override the taxonomy template from your theme. <a href="%s" target="_blank" rel="noopener noreferrer">Read the documentation for customizing these designs</a>.', 'organize-series'),
+										esc_url('https://publishpress.com/knowledge-base/series-archive-templates/')
 										);
 										?>
 									</p>

--- a/js/orgseries_options.js
+++ b/js/orgseries_options.js
@@ -5,11 +5,11 @@ jQuery(document).ready(function($) {
         return false;
     });
 
-    $('input#TBcancel').click(function(){
+    $('#TBcancel').click(function(){
         tb_remove();
     });
 
-    $('input#TBsubmit').click(function(){
+    $('#TBsubmit').click(function(){
 		$('input.reset_option', '#series_options' ).val('1');
         document.series_options.submit();
     });

--- a/orgSeries-admin.css
+++ b/orgSeries-admin.css
@@ -33,7 +33,7 @@
     text-align: left;
 }
 
-#serieschecklist li label input:checked ~ .selected-series-order {
+#serieschecklist li input:checked ~ .selected-series-order {
     display: inline-block !important;
     margin-left: 5px;
 }

--- a/orgSeries-admin.php
+++ b/orgSeries-admin.php
@@ -338,15 +338,14 @@ function write_series_list($series)
 	foreach ((array)$series as $serial) {
 		$series_order_link = admin_url('edit.php?page=manage-issues&action=part&series_ID');
 		$serial_html = '<li id="series-' . esc_attr($serial['series_ID']) . '">
-                    <label for="in-series-' . esc_attr($serial['series_ID']) . '" class="selectit">
                         <input value="' . esc_attr($serial['series_ID']) . '" type="radio" name="post_series" id="in-series-' . esc_attr($serial['series_ID']) . '"' . ($serial['checked'] ? ' checked="checked"' : '') . '/> 
-                        <span class="li-series-name">' . esc_html($serial['ser_name']) . "</span>
-                        <a class='selected-series-order' style='text-decoration: none;display:none;' href='" . admin_url("edit.php?page=manage-issues&action=part&series_ID=" . $serial['series_ID'] . "") . "' target='blank'>
+                        <label for="in-series-' . esc_attr($serial['series_ID']) . '" class="selectit">
+                            <span class="li-series-name">' . esc_html($serial['ser_name']) . "</span>
+                        </label>
+                        <a class='selected-series-order' style='text-decoration: none;display:none;' href='" . admin_url("edit.php?page=manage-issues&action=part&series_ID=" . $serial['series_ID'] . "") . "' target='_blank' rel='noopener noreferrer'>
                              " . __('Series Order', 'organize-series') . "
-                             <span class='dashicons dashicons-external'></span>
+                             <span class='dashicons dashicons-external' aria-hidden='true'></span>
                         </a>
-                        
-                    </label>
                 </li>";
 		if ($serial['checked']) {
 			$checked_series_html .= $serial_html;


### PR DESCRIPTION
## Summary
- give the Series reset confirmation a dialog name, description, and semantic buttons
- replace vague documentation links with descriptive text
- remove labels from non-control table headings and descriptions
- keep the Series Order link outside the radio label while preserving its checked-state styling

## Accessibility finding
Addresses finding 8 from the Series Free accessibility audit: the reset confirmation lacked dialog semantics, links used vague text, and several labels were not associated with form controls.

## Validation
- php -l on changed PHP files
- node --check js/orgseries_options.js
- git diff --check