### PR TITLE
fix(settings): allowlist series_posts_orderby and series_posts_order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+[Unreleased]
+
+* Fixed: Allowlist `series_posts_orderby` and `series_posts_order` before they reach series archive ORDER BY (Patchstack 34965)
+
 [3.1.3] - 17 Aug, 2026
 
 * Added: Add a welcome panel with the first steps for new users #1170

--- a/inc/settings/settings-validation.php
+++ b/inc/settings/settings-validation.php
@@ -44,6 +44,26 @@ function ppseries_sanitize_int( $input, $key ) {
 }
 
 /**
+ * Allowed series_posts_orderby option values mapped to ORDER BY SQL fragments.
+ */
+function ppseries_series_posts_orderby_sql() {
+	return [
+		'meta_value' => 'orgmeta.meta_value+ 0',
+		'post_date'  => 'post_date',
+	];
+}
+
+/**
+ * Allowed series_posts_order option values mapped to ORDER BY directions.
+ */
+function ppseries_series_posts_order_sql() {
+	return [
+		'ASC'  => 'ASC',
+		'DESC' => 'DESC',
+	];
+}
+
+/**
  * Register a temporary taxonomy for term migration.
  */
 function ppseries_register_temporary_taxonomy() {
@@ -275,8 +295,13 @@ function orgseries_validate( $input ) {
 		$newinput['series_toc_url'] = false;
 	}
 
-	$newinput['series_posts_orderby']      = ppseries_sanitize_text( $input, 'series_posts_orderby', $existing );
-	$newinput['series_posts_order']        = ppseries_sanitize_text( $input, 'series_posts_order', $existing );
+	$orderby = ppseries_sanitize_text( $input, 'series_posts_orderby', $existing );
+	$allowed_orderby = ppseries_series_posts_orderby_sql();
+	$newinput['series_posts_orderby'] = isset( $allowed_orderby[ $orderby ] ) ? $orderby : 'meta_value';
+
+	$order = ppseries_sanitize_text( $input, 'series_posts_order', $existing );
+	$allowed_order = ppseries_series_posts_order_sql();
+	$newinput['series_posts_order'] = isset( $allowed_order[ $order ] ) ? $order : 'ASC';
 	$newinput['series_post_list_limit']    = ppseries_sanitize_text( $input, 'series_post_list_limit', $existing );
 	$newinput['limit_series_meta_to_single'] = ppseries_sanitize_checkbox( $input, 'limit_series_meta_to_single' );
 

--- a/orgSeries-setup.php
+++ b/orgSeries-setup.php
@@ -603,17 +603,12 @@ class orgSeries {
 				return $ordering;
 			}
 			$settings = $this->settings;
-			$orderby  = $settings['series_posts_orderby'];
-			if ( $orderby == 'meta_value' ) {
-				$orderby = 'orgmeta.' . $orderby . '+ 0';
-			}
-			$order = $settings['series_posts_order'];
-			if ( ! isset( $orderby ) ) {
-				$orderby = "post_date";
-			}
-			if ( ! isset( $order ) ) {
-				$order = "DESC";
-			}
+			$orderby_sql = ppseries_series_posts_orderby_sql();
+			$order_sql = ppseries_series_posts_order_sql();
+			$orderby_key = isset( $settings['series_posts_orderby'] ) ? $settings['series_posts_orderby'] : 'meta_value';
+			$order_key = isset( $settings['series_posts_order'] ) ? $settings['series_posts_order'] : 'ASC';
+			$orderby = isset( $orderby_sql[ $orderby_key ] ) ? $orderby_sql[ $orderby_key ] : $orderby_sql['meta_value'];
+			$order = isset( $order_sql[ $order_key ] ) ? $order_sql[ $order_key ] : $order_sql['ASC'];
 			$ordering = " $orderby $order ";
 		}
 		return apply_filters('orgseries_sort_series_page_orderby', $ordering);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Patchstack report 34965. Settings API values `org_series_options[series_posts_orderby]` and `org_series_options[series_posts_order]` were stored after `trim(stripslashes)` only. `sort_series_page_orderby()` then concatenated those strings into the series archive `ORDER BY` clause.

This change allowlists the documented sort column and direction at save time and at the SQL sink. Only server-defined fragments can reach `posts_orderby`.

## Scope

- `ppseries_series_posts_orderby_sql()` and `ppseries_series_posts_order_sql()` in `inc/settings/settings-validation.php`
- `orgseries_validate()` now keeps `meta_value` or `post_date`, and `ASC` or `DESC`
- `sort_series_page_orderby()` in `orgSeries-setup.php` interpolates mapped fragments only, including `orgmeta.meta_value+ 0` for series part
- Changelog unreleased note

Out of scope: Settings API nonce and capability checks, the Legacy settings radios, and the `orgseries_sort_series_page_orderby` filter.

## Tradeoffs

The sink allowlists stored options as well as new submissions. A previously saved invalid value cannot reach `ORDER BY` while it waits for the next settings save.

## Blast Radius

Series taxonomy archive sort order. Documented Series part and date sorts keep the same SQL. Invalid stored values fall back to `meta_value` and `ASC`, which matches the plugin defaults.

## Verification

PHP CLI checks of the allowlist maps, the settings save path, and the sink source. Documented options still produce `orgmeta.meta_value+ 0` and `post_date` with `ASC` or `DESC`. Unknown column and direction values no longer appear in the `ORDER BY` fragment. The settings nonce and `manage_publishpress_series` checks are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f00b2d7-5b8b-4a74-ad25-1aa8952dbc6a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f00b2d7-5b8b-4a74-ad25-1aa8952dbc6a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

